### PR TITLE
Added support for sending a stream of data for a document signature.

### DIFF
--- a/tests/com/docusign/esignature/tests/RequestSignatureDocument.java
+++ b/tests/com/docusign/esignature/tests/RequestSignatureDocument.java
@@ -46,7 +46,7 @@ public class RequestSignatureDocument
 		// STEP 2 - Create an envelope with one recipient, document, and tab and send
 		// 
 		RequestSignatureFromDocuments request = new RequestSignatureFromDocuments();
-		String envelopeId = client.reqeustSignatureFromDocuments(request, null);
+		String envelopeId = client.reqeustSignatureFromDocuments(request, new InputStream[0]);
 		Assert.assertNotNull(envelopeId);
 		Assert.assertTrue(envelopeId.length() > 0);
 		


### PR DESCRIPTION
This will allow sending a stream of data instead of a flat file. This is necessary to support systems that have a ephemeral file system or where it is not desired to store all of the file data in memory or on the file system (ex. streaming from a URL to DocuSign).
