### PR TITLE
Version 3.8.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ jdk:
 script: mvn -X clean test
 
 after_failure: "cat /home/travis/build/docusign/docusign-java-client/target/surefire-reports/SdkUnitTests.txt && cat /home/travis/build/docusign/docusign-java-client/target/surefire-reports/TEST-SdkUnitTests.xml"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # DocuSign Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [3.8.0] - Jersey2 with support of DELETE request body - 2020-08-21
+### Changed
+- Upgraded the HTTP client from Jersey1 to Jersey 2. This resulted in a non-breaking change but the dependency list has largely been changed. (DCM-3324)
+- Added support for request body in all DELETE methods. (DCM-4454)
+- Added support for version v2.1-20.2.02 of the DocuSign eSignature API.
+- Updated the SDK release version.
+
 ## [3.8.0-BETA] - Jersey2 with support of DELETE request body - 2020-08-11
 ### Changed
 - Upgraded the HTTP client from Jersey1 to Jersey 2. This resulted in a non-breaking change but the dependency list has largely been changed. (DCM-3324)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Note: DocuSign uses **Eclipse** with **Maven** for testing purposes.
 <dependency>
   <groupId>com.docusign</groupId>
   <artifactId>docusign-esign-java</artifactId>
-  <version>3.8.0-BETA</version>
+  <version>3.8.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group = 'com.docusign'
-version = '3.8.0-BETA'
+version = '3.8.0'
 
 buildscript {
     repositories {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>docusign-esign-java</artifactId>
   <packaging>jar</packaging>
   <name>docusign-esign-java</name>
-  <version>3.8.0-BETA</version>
+  <version>3.8.0</version>
   <description>The official DocuSign eSignature JAVA client is based on version 2 of the DocuSign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
   <url>https://developers.docusign.com</url>
 

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -87,7 +87,7 @@ public class ApiClient {
     this.dateFormat = new RFC3339DateFormat();
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/3.8.0-BETA/java");
+    setUserAgent("Swagger-Codegen/3.8.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();


### PR DESCRIPTION
### Changed
- Upgraded the HTTP client from Jersey1 to Jersey 2. This resulted in a non-breaking change but the dependency list
 has largely been changed. (DCM-3324)
- Added support for request body in all DELETE methods. (DCM-4454)
- Added support for version v2.1-20.2.02 of the DocuSign eSignature API.
- Updated the SDK release version.