### PR TITLE
Version 4.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # DocuSign Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v4.6.0] - eSignature API v2.1-23.4.02.00 - 2024-04-30
+### BREAKING CHANGES
+- Modified the default basePath to `DEMO_REST_BASEPATH`.
+### OTHER CHANGES
+- Revised the logic to determine the `oAuthBasePath` based on the `basePath`.
+- Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.
+- Updated the SDK release version.
+
 ## [v4.6.0-RC1] - eSignature API v2.1-23.4.02.00 - 2024-03-12
 ### Changed
 - Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>docusign-esign-java</artifactId>
     <packaging>jar</packaging>
     <name>docusign-esign-java</name>
-    <version>4.6.0-RC1</version>
+    <version>4.6.0</version>
     <url>https://developers.docusign.com</url>
     <description>The official DocuSign eSignature JAVA client is based on version 2.1 of the DocuSign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
 

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -96,7 +96,7 @@ public class ApiClient {
     String javaVersion = System.getProperty("java.version");
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/v2.1/4.6.0-RC1/Java/" + javaVersion);
+    setUserAgent("Swagger-Codegen/v2.1/4.6.0/Java/" + javaVersion);
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();


### PR DESCRIPTION
### BREAKING CHANGES
- Modified the default basePath to `DEMO_REST_BASEPATH`.
### OTHER CHANGES
- Revised the logic to determine the `oAuthBasePath` based on the `basePath`.
- Added support for version v2.1-23.4.02.00 of the DocuSign ESignature API.
- Updated the SDK release version.
