### PR TITLE
Version 6.0.0-RC1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # DocuSign Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v6.0.0-RC1] - eSignature API v2.1-24.2.00.00 - 2024-06-28
+### Changed
+- Added support for version v2.1-24.2.00.00 of the DocuSign ESignature API.
+- Updated the SDK release version.
+
 ## [v5.1.0] - eSignature API v2.1-24.1.01.00 - 2024-06-25
 # Changed
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This client SDK is provided as open source, which enables you to customize its f
     <dependency>
       <groupId>com.docusign</groupId>
       <artifactId>docusign-esign-java</artifactId>
-      <version>5.1.0</version>
+      <version>6.0.0-RC1</version>
     </dependency>
     ```
 8. If your project is still open, restart Eclipse.
@@ -116,5 +116,5 @@ The Docusign eSignature Java Client SDK is licensed under the [MIT License](http
 
 [travis-image]: https://api.travis-ci.com/docusign/docusign-esign-java-client.svg?branch=master
 [travis-url]: https://app.travis-ci.com/github/docusign/docusign-esign-java-client
-[maven-image]: https://img.shields.io/maven-central/v/com.docusign/docusign-esign-java.svg?style=flat
+[maven-image]: https://img.shields.io/maven-central/v/com.docusign/.svg?style=flat
 [maven-url]: https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.docusign%22

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>docusign-esign-java</artifactId>
     <packaging>jar</packaging>
     <name>docusign-esign-java</name>
-    <version>5.1.0</version>
+    <version>6.0.0-RC1</version>
     <url>https://developers.docusign.com</url>
     <description>The official DocuSign eSignature JAVA client is based on version 2.1 of the DocuSign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
 

--- a/src/main/java/com/docusign/esign/api/EnvelopesApi.java
+++ b/src/main/java/com/docusign/esign/api/EnvelopesApi.java
@@ -420,12 +420,12 @@ public class EnvelopesApi {
    * Returns a URL that allows you to embed the envelope correction view of the DocuSign UI in your applications.  Important: iFrames should not be used for embedded operations on mobile devices due to screen space issues. For iOS devices DocuSign recommends using a WebView. 
    * @param accountId The external account number (int) or account ID Guid. (required)
    * @param envelopeId The envelopeId Guid of the envelope being accessed. (required)
-   * @param correctViewRequest  (optional)
+   * @param envelopeViewRequest  (optional)
    * @return ViewUrl
    * @throws ApiException if fails to make API call
    */
-  public ViewUrl createCorrectView(String accountId, String envelopeId, CorrectViewRequest correctViewRequest) throws ApiException {
-    ApiResponse<ViewUrl> localVarResponse = createCorrectViewWithHttpInfo(accountId, envelopeId, correctViewRequest);
+  public ViewUrl createCorrectView(String accountId, String envelopeId, EnvelopeViewRequest envelopeViewRequest) throws ApiException {
+    ApiResponse<ViewUrl> localVarResponse = createCorrectViewWithHttpInfo(accountId, envelopeId, envelopeViewRequest);
     return localVarResponse.getData();
   }
 
@@ -434,12 +434,12 @@ public class EnvelopesApi {
    * Returns a URL that allows you to embed the envelope correction view of the DocuSign UI in your applications.  Important: iFrames should not be used for embedded operations on mobile devices due to screen space issues. For iOS devices DocuSign recommends using a WebView. 
    * @param accountId The external account number (int) or account ID Guid. (required)
    * @param envelopeId The envelopeId Guid of the envelope being accessed. (required)
-   * @param correctViewRequest  (optional)
+   * @param envelopeViewRequest  (optional)
    * @return ViewUrl
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<ViewUrl > createCorrectViewWithHttpInfo(String accountId, String envelopeId, CorrectViewRequest correctViewRequest) throws ApiException {
-    Object localVarPostBody = correctViewRequest;
+  public ApiResponse<ViewUrl > createCorrectViewWithHttpInfo(String accountId, String envelopeId, EnvelopeViewRequest envelopeViewRequest) throws ApiException {
+    Object localVarPostBody = envelopeViewRequest;
     
     // verify the required parameter 'accountId' is set
     if (accountId == null) {
@@ -5247,6 +5247,7 @@ public class EnvelopesApi {
   {
   private String advancedUpdate = null;
   private String include = null;
+  private String includeAnchorTabLocations = null;
   
  /**
   * setAdvancedUpdate method.
@@ -5278,6 +5279,22 @@ public class EnvelopesApi {
   */
   public String getInclude() {
     return this.include;
+  }
+  
+ /**
+  * setIncludeAnchorTabLocations method.
+  */
+  public void setIncludeAnchorTabLocations(String includeAnchorTabLocations) {
+    this.includeAnchorTabLocations = includeAnchorTabLocations;
+  }
+
+ /**
+  * getIncludeAnchorTabLocations method.
+  *
+  * @return String
+  */
+  public String getIncludeAnchorTabLocations() {
+    return this.includeAnchorTabLocations;
   }
   }
 
@@ -5343,6 +5360,8 @@ public class EnvelopesApi {
       localVarQueryParams.addAll(apiClient.parameterToPair("advanced_update", options.advancedUpdate));
     }if (options != null) {
       localVarQueryParams.addAll(apiClient.parameterToPair("include", options.include));
+    }if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("include_anchor_tab_locations", options.includeAnchorTabLocations));
     }
 
     
@@ -9530,6 +9549,7 @@ public class EnvelopesApi {
   public class UpdateOptions
   {
   private String advancedUpdate = null;
+  private String recycleOnVoid = null;
   private String resendEnvelope = null;
   
  /**
@@ -9546,6 +9566,22 @@ public class EnvelopesApi {
   */
   public String getAdvancedUpdate() {
     return this.advancedUpdate;
+  }
+  
+ /**
+  * setRecycleOnVoid method.
+  */
+  public void setRecycleOnVoid(String recycleOnVoid) {
+    this.recycleOnVoid = recycleOnVoid;
+  }
+
+ /**
+  * getRecycleOnVoid method.
+  *
+  * @return String
+  */
+  public String getRecycleOnVoid() {
+    return this.recycleOnVoid;
   }
   
  /**
@@ -9628,6 +9664,8 @@ public class EnvelopesApi {
 
     if (options != null) {
       localVarQueryParams.addAll(apiClient.parameterToPair("advanced_update", options.advancedUpdate));
+    }if (options != null) {
+      localVarQueryParams.addAll(apiClient.parameterToPair("recycle_on_void", options.recycleOnVoid));
     }if (options != null) {
       localVarQueryParams.addAll(apiClient.parameterToPair("resend_envelope", options.resendEnvelope));
     }

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -96,7 +96,7 @@ public class ApiClient {
     String javaVersion = System.getProperty("java.version");
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/v2.1/5.1.0/Java/" + javaVersion);
+    setUserAgent("Swagger-Codegen/v2.1/6.0.0-RC1/Java/" + javaVersion);
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();

--- a/src/main/java/com/docusign/esign/model/AccountInformation.java
+++ b/src/main/java/com/docusign/esign/model/AccountInformation.java
@@ -95,6 +95,9 @@ public class AccountInformation implements Serializable {
   @JsonProperty("forgottenPasswordQuestionsCount")
   private String forgottenPasswordQuestionsCount = null;
 
+  @JsonProperty("freeEnvelopeSendsRemainingForAdvancedDocGen")
+  private Integer freeEnvelopeSendsRemainingForAdvancedDocGen = null;
+
   @JsonProperty("isDowngrade")
   private String isDowngrade = null;
 
@@ -824,6 +827,33 @@ public class AccountInformation implements Serializable {
 
 
   /**
+   * freeEnvelopeSendsRemainingForAdvancedDocGen.
+   *
+   * @return AccountInformation
+   **/
+  public AccountInformation freeEnvelopeSendsRemainingForAdvancedDocGen(Integer freeEnvelopeSendsRemainingForAdvancedDocGen) {
+    this.freeEnvelopeSendsRemainingForAdvancedDocGen = freeEnvelopeSendsRemainingForAdvancedDocGen;
+    return this;
+  }
+
+  /**
+   * .
+   * @return freeEnvelopeSendsRemainingForAdvancedDocGen
+   **/
+  @Schema(description = "")
+  public Integer getFreeEnvelopeSendsRemainingForAdvancedDocGen() {
+    return freeEnvelopeSendsRemainingForAdvancedDocGen;
+  }
+
+  /**
+   * setFreeEnvelopeSendsRemainingForAdvancedDocGen.
+   **/
+  public void setFreeEnvelopeSendsRemainingForAdvancedDocGen(Integer freeEnvelopeSendsRemainingForAdvancedDocGen) {
+    this.freeEnvelopeSendsRemainingForAdvancedDocGen = freeEnvelopeSendsRemainingForAdvancedDocGen;
+  }
+
+
+  /**
    * isDowngrade.
    *
    * @return AccountInformation
@@ -1226,6 +1256,7 @@ public class AccountInformation implements Serializable {
         Objects.equals(this.envelopeUnitPrice, accountInformation.envelopeUnitPrice) &&
         Objects.equals(this.externalAccountId, accountInformation.externalAccountId) &&
         Objects.equals(this.forgottenPasswordQuestionsCount, accountInformation.forgottenPasswordQuestionsCount) &&
+        Objects.equals(this.freeEnvelopeSendsRemainingForAdvancedDocGen, accountInformation.freeEnvelopeSendsRemainingForAdvancedDocGen) &&
         Objects.equals(this.isDowngrade, accountInformation.isDowngrade) &&
         Objects.equals(this.paymentMethod, accountInformation.paymentMethod) &&
         Objects.equals(this.planClassification, accountInformation.planClassification) &&
@@ -1246,7 +1277,7 @@ public class AccountInformation implements Serializable {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(accountIdGuid, accountName, accountSettings, allowTransactionRooms, billingPeriodDaysRemaining, billingPeriodEndDate, billingPeriodEnvelopesAllowed, billingPeriodEnvelopesSent, billingPeriodStartDate, billingProfile, brands, canUpgrade, connectPermission, createdDate, currencyCode, currentPlanId, displayApplianceStartUrl, displayApplianceUrl, distributorCode, docuSignLandingUrl, dssValues, envelopeSendingBlocked, envelopeUnitPrice, externalAccountId, forgottenPasswordQuestionsCount, isDowngrade, paymentMethod, planClassification, planEndDate, planName, planStartDate, recipientDomains, seatsAllowed, seatsInUse, status21CFRPart11, suspensionDate, suspensionStatus, useDisplayAppliance);
+    return Objects.hash(accountIdGuid, accountName, accountSettings, allowTransactionRooms, billingPeriodDaysRemaining, billingPeriodEndDate, billingPeriodEnvelopesAllowed, billingPeriodEnvelopesSent, billingPeriodStartDate, billingProfile, brands, canUpgrade, connectPermission, createdDate, currencyCode, currentPlanId, displayApplianceStartUrl, displayApplianceUrl, distributorCode, docuSignLandingUrl, dssValues, envelopeSendingBlocked, envelopeUnitPrice, externalAccountId, forgottenPasswordQuestionsCount, freeEnvelopeSendsRemainingForAdvancedDocGen, isDowngrade, paymentMethod, planClassification, planEndDate, planName, planStartDate, recipientDomains, seatsAllowed, seatsInUse, status21CFRPart11, suspensionDate, suspensionStatus, useDisplayAppliance);
   }
 
 
@@ -1283,6 +1314,7 @@ public class AccountInformation implements Serializable {
     sb.append("    envelopeUnitPrice: ").append(toIndentedString(envelopeUnitPrice)).append("\n");
     sb.append("    externalAccountId: ").append(toIndentedString(externalAccountId)).append("\n");
     sb.append("    forgottenPasswordQuestionsCount: ").append(toIndentedString(forgottenPasswordQuestionsCount)).append("\n");
+    sb.append("    freeEnvelopeSendsRemainingForAdvancedDocGen: ").append(toIndentedString(freeEnvelopeSendsRemainingForAdvancedDocGen)).append("\n");
     sb.append("    isDowngrade: ").append(toIndentedString(isDowngrade)).append("\n");
     sb.append("    paymentMethod: ").append(toIndentedString(paymentMethod)).append("\n");
     sb.append("    planClassification: ").append(toIndentedString(planClassification)).append("\n");

--- a/src/main/java/com/docusign/esign/model/AccountSettingsInformation.java
+++ b/src/main/java/com/docusign/esign/model/AccountSettingsInformation.java
@@ -858,6 +858,12 @@ public class AccountSettingsInformation implements Serializable {
   @JsonProperty("dataPopulationScopeMetadata")
   private SettingsMetadata dataPopulationScopeMetadata = null;
 
+  @JsonProperty("defaultSigningResponsiveView")
+  private String defaultSigningResponsiveView = null;
+
+  @JsonProperty("defaultSigningResponsiveViewMetadata")
+  private SettingsMetadata defaultSigningResponsiveViewMetadata = null;
+
   @JsonProperty("defaultToAdvancedEnvelopesFilterForm")
   private String defaultToAdvancedEnvelopesFilterForm = null;
 
@@ -972,6 +978,9 @@ public class AccountSettingsInformation implements Serializable {
   @JsonProperty("dss_EnableSignatureTypeCustomTagRadmin_RadminOption")
   private String dssEnableSignatureTypeCustomTagRadminRadminOption = null;
 
+  @JsonProperty("dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb")
+  private String dssSCOREFDN196RebrandDocuSignIsNotAVerb = null;
+
   @JsonProperty("dss_SIGN_28411_EnableLeavePagePrompt_RadminOption")
   private String dssSIGN28411EnableLeavePagePromptRadminOption = null;
 
@@ -995,6 +1004,12 @@ public class AccountSettingsInformation implements Serializable {
 
   @JsonProperty("enableAccountWideSearchMetadata")
   private SettingsMetadata enableAccountWideSearchMetadata = null;
+
+  @JsonProperty("enableAdditionalAdvancedWebFormsFeatures")
+  private String enableAdditionalAdvancedWebFormsFeatures = null;
+
+  @JsonProperty("enableAdditionalAdvancedWebFormsFeaturesMetadata")
+  private SettingsMetadata enableAdditionalAdvancedWebFormsFeaturesMetadata = null;
 
   @JsonProperty("enableAdmHealthcare")
   private String enableAdmHealthcare = null;
@@ -1328,12 +1343,6 @@ public class AccountSettingsInformation implements Serializable {
 
   @JsonProperty("enableResponsiveSigningMetadata")
   private SettingsMetadata enableResponsiveSigningMetadata = null;
-
-  @JsonProperty("enableSaveAsEnvelopeCustomFieldInWebForms")
-  private String enableSaveAsEnvelopeCustomFieldInWebForms = null;
-
-  @JsonProperty("enableSaveAsEnvelopeCustomFieldInWebFormsMetadata")
-  private SettingsMetadata enableSaveAsEnvelopeCustomFieldInWebFormsMetadata = null;
 
   @JsonProperty("enableScheduledRelease")
   private String enableScheduledRelease = null;
@@ -9755,6 +9764,60 @@ public class AccountSettingsInformation implements Serializable {
 
 
   /**
+   * defaultSigningResponsiveView.
+   *
+   * @return AccountSettingsInformation
+   **/
+  public AccountSettingsInformation defaultSigningResponsiveView(String defaultSigningResponsiveView) {
+    this.defaultSigningResponsiveView = defaultSigningResponsiveView;
+    return this;
+  }
+
+  /**
+   * .
+   * @return defaultSigningResponsiveView
+   **/
+  @Schema(description = "")
+  public String getDefaultSigningResponsiveView() {
+    return defaultSigningResponsiveView;
+  }
+
+  /**
+   * setDefaultSigningResponsiveView.
+   **/
+  public void setDefaultSigningResponsiveView(String defaultSigningResponsiveView) {
+    this.defaultSigningResponsiveView = defaultSigningResponsiveView;
+  }
+
+
+  /**
+   * defaultSigningResponsiveViewMetadata.
+   *
+   * @return AccountSettingsInformation
+   **/
+  public AccountSettingsInformation defaultSigningResponsiveViewMetadata(SettingsMetadata defaultSigningResponsiveViewMetadata) {
+    this.defaultSigningResponsiveViewMetadata = defaultSigningResponsiveViewMetadata;
+    return this;
+  }
+
+  /**
+   * .
+   * @return defaultSigningResponsiveViewMetadata
+   **/
+  @Schema(description = "")
+  public SettingsMetadata getDefaultSigningResponsiveViewMetadata() {
+    return defaultSigningResponsiveViewMetadata;
+  }
+
+  /**
+   * setDefaultSigningResponsiveViewMetadata.
+   **/
+  public void setDefaultSigningResponsiveViewMetadata(SettingsMetadata defaultSigningResponsiveViewMetadata) {
+    this.defaultSigningResponsiveViewMetadata = defaultSigningResponsiveViewMetadata;
+  }
+
+
+  /**
    * defaultToAdvancedEnvelopesFilterForm.
    *
    * @return AccountSettingsInformation
@@ -10781,6 +10844,33 @@ public class AccountSettingsInformation implements Serializable {
 
 
   /**
+   * dssSCOREFDN196RebrandDocuSignIsNotAVerb.
+   *
+   * @return AccountSettingsInformation
+   **/
+  public AccountSettingsInformation dssSCOREFDN196RebrandDocuSignIsNotAVerb(String dssSCOREFDN196RebrandDocuSignIsNotAVerb) {
+    this.dssSCOREFDN196RebrandDocuSignIsNotAVerb = dssSCOREFDN196RebrandDocuSignIsNotAVerb;
+    return this;
+  }
+
+  /**
+   * .
+   * @return dssSCOREFDN196RebrandDocuSignIsNotAVerb
+   **/
+  @Schema(description = "")
+  public String getDssSCOREFDN196RebrandDocuSignIsNotAVerb() {
+    return dssSCOREFDN196RebrandDocuSignIsNotAVerb;
+  }
+
+  /**
+   * setDssSCOREFDN196RebrandDocuSignIsNotAVerb.
+   **/
+  public void setDssSCOREFDN196RebrandDocuSignIsNotAVerb(String dssSCOREFDN196RebrandDocuSignIsNotAVerb) {
+    this.dssSCOREFDN196RebrandDocuSignIsNotAVerb = dssSCOREFDN196RebrandDocuSignIsNotAVerb;
+  }
+
+
+  /**
    * dssSIGN28411EnableLeavePagePromptRadminOption.
    *
    * @return AccountSettingsInformation
@@ -10993,6 +11083,60 @@ public class AccountSettingsInformation implements Serializable {
    **/
   public void setEnableAccountWideSearchMetadata(SettingsMetadata enableAccountWideSearchMetadata) {
     this.enableAccountWideSearchMetadata = enableAccountWideSearchMetadata;
+  }
+
+
+  /**
+   * enableAdditionalAdvancedWebFormsFeatures.
+   *
+   * @return AccountSettingsInformation
+   **/
+  public AccountSettingsInformation enableAdditionalAdvancedWebFormsFeatures(String enableAdditionalAdvancedWebFormsFeatures) {
+    this.enableAdditionalAdvancedWebFormsFeatures = enableAdditionalAdvancedWebFormsFeatures;
+    return this;
+  }
+
+  /**
+   * .
+   * @return enableAdditionalAdvancedWebFormsFeatures
+   **/
+  @Schema(description = "")
+  public String getEnableAdditionalAdvancedWebFormsFeatures() {
+    return enableAdditionalAdvancedWebFormsFeatures;
+  }
+
+  /**
+   * setEnableAdditionalAdvancedWebFormsFeatures.
+   **/
+  public void setEnableAdditionalAdvancedWebFormsFeatures(String enableAdditionalAdvancedWebFormsFeatures) {
+    this.enableAdditionalAdvancedWebFormsFeatures = enableAdditionalAdvancedWebFormsFeatures;
+  }
+
+
+  /**
+   * enableAdditionalAdvancedWebFormsFeaturesMetadata.
+   *
+   * @return AccountSettingsInformation
+   **/
+  public AccountSettingsInformation enableAdditionalAdvancedWebFormsFeaturesMetadata(SettingsMetadata enableAdditionalAdvancedWebFormsFeaturesMetadata) {
+    this.enableAdditionalAdvancedWebFormsFeaturesMetadata = enableAdditionalAdvancedWebFormsFeaturesMetadata;
+    return this;
+  }
+
+  /**
+   * .
+   * @return enableAdditionalAdvancedWebFormsFeaturesMetadata
+   **/
+  @Schema(description = "")
+  public SettingsMetadata getEnableAdditionalAdvancedWebFormsFeaturesMetadata() {
+    return enableAdditionalAdvancedWebFormsFeaturesMetadata;
+  }
+
+  /**
+   * setEnableAdditionalAdvancedWebFormsFeaturesMetadata.
+   **/
+  public void setEnableAdditionalAdvancedWebFormsFeaturesMetadata(SettingsMetadata enableAdditionalAdvancedWebFormsFeaturesMetadata) {
+    this.enableAdditionalAdvancedWebFormsFeaturesMetadata = enableAdditionalAdvancedWebFormsFeaturesMetadata;
   }
 
 
@@ -13990,60 +14134,6 @@ public class AccountSettingsInformation implements Serializable {
    **/
   public void setEnableResponsiveSigningMetadata(SettingsMetadata enableResponsiveSigningMetadata) {
     this.enableResponsiveSigningMetadata = enableResponsiveSigningMetadata;
-  }
-
-
-  /**
-   * enableSaveAsEnvelopeCustomFieldInWebForms.
-   *
-   * @return AccountSettingsInformation
-   **/
-  public AccountSettingsInformation enableSaveAsEnvelopeCustomFieldInWebForms(String enableSaveAsEnvelopeCustomFieldInWebForms) {
-    this.enableSaveAsEnvelopeCustomFieldInWebForms = enableSaveAsEnvelopeCustomFieldInWebForms;
-    return this;
-  }
-
-  /**
-   * .
-   * @return enableSaveAsEnvelopeCustomFieldInWebForms
-   **/
-  @Schema(description = "")
-  public String getEnableSaveAsEnvelopeCustomFieldInWebForms() {
-    return enableSaveAsEnvelopeCustomFieldInWebForms;
-  }
-
-  /**
-   * setEnableSaveAsEnvelopeCustomFieldInWebForms.
-   **/
-  public void setEnableSaveAsEnvelopeCustomFieldInWebForms(String enableSaveAsEnvelopeCustomFieldInWebForms) {
-    this.enableSaveAsEnvelopeCustomFieldInWebForms = enableSaveAsEnvelopeCustomFieldInWebForms;
-  }
-
-
-  /**
-   * enableSaveAsEnvelopeCustomFieldInWebFormsMetadata.
-   *
-   * @return AccountSettingsInformation
-   **/
-  public AccountSettingsInformation enableSaveAsEnvelopeCustomFieldInWebFormsMetadata(SettingsMetadata enableSaveAsEnvelopeCustomFieldInWebFormsMetadata) {
-    this.enableSaveAsEnvelopeCustomFieldInWebFormsMetadata = enableSaveAsEnvelopeCustomFieldInWebFormsMetadata;
-    return this;
-  }
-
-  /**
-   * .
-   * @return enableSaveAsEnvelopeCustomFieldInWebFormsMetadata
-   **/
-  @Schema(description = "")
-  public SettingsMetadata getEnableSaveAsEnvelopeCustomFieldInWebFormsMetadata() {
-    return enableSaveAsEnvelopeCustomFieldInWebFormsMetadata;
-  }
-
-  /**
-   * setEnableSaveAsEnvelopeCustomFieldInWebFormsMetadata.
-   **/
-  public void setEnableSaveAsEnvelopeCustomFieldInWebFormsMetadata(SettingsMetadata enableSaveAsEnvelopeCustomFieldInWebFormsMetadata) {
-    this.enableSaveAsEnvelopeCustomFieldInWebFormsMetadata = enableSaveAsEnvelopeCustomFieldInWebFormsMetadata;
   }
 
 
@@ -22841,6 +22931,8 @@ public class AccountSettingsInformation implements Serializable {
         Objects.equals(this.convertPdfFieldsMetadata, accountSettingsInformation.convertPdfFieldsMetadata) &&
         Objects.equals(this.dataPopulationScope, accountSettingsInformation.dataPopulationScope) &&
         Objects.equals(this.dataPopulationScopeMetadata, accountSettingsInformation.dataPopulationScopeMetadata) &&
+        Objects.equals(this.defaultSigningResponsiveView, accountSettingsInformation.defaultSigningResponsiveView) &&
+        Objects.equals(this.defaultSigningResponsiveViewMetadata, accountSettingsInformation.defaultSigningResponsiveViewMetadata) &&
         Objects.equals(this.defaultToAdvancedEnvelopesFilterForm, accountSettingsInformation.defaultToAdvancedEnvelopesFilterForm) &&
         Objects.equals(this.defaultToAdvancedEnvelopesFilterFormMetadata, accountSettingsInformation.defaultToAdvancedEnvelopesFilterFormMetadata) &&
         Objects.equals(this.disableAutoTemplateMatching, accountSettingsInformation.disableAutoTemplateMatching) &&
@@ -22879,6 +22971,7 @@ public class AccountSettingsInformation implements Serializable {
         Objects.equals(this.draftEnvelopeRetentionMetadata, accountSettingsInformation.draftEnvelopeRetentionMetadata) &&
         Objects.equals(this.dssEnableProvisioningPenConfigurationRadminOption, accountSettingsInformation.dssEnableProvisioningPenConfigurationRadminOption) &&
         Objects.equals(this.dssEnableSignatureTypeCustomTagRadminRadminOption, accountSettingsInformation.dssEnableSignatureTypeCustomTagRadminRadminOption) &&
+        Objects.equals(this.dssSCOREFDN196RebrandDocuSignIsNotAVerb, accountSettingsInformation.dssSCOREFDN196RebrandDocuSignIsNotAVerb) &&
         Objects.equals(this.dssSIGN28411EnableLeavePagePromptRadminOption, accountSettingsInformation.dssSIGN28411EnableLeavePagePromptRadminOption) &&
         Objects.equals(this.dssSIGN29182SlideUpBarRadminOption, accountSettingsInformation.dssSIGN29182SlideUpBarRadminOption) &&
         Objects.equals(this.emailTemplateVersion, accountSettingsInformation.emailTemplateVersion) &&
@@ -22887,6 +22980,8 @@ public class AccountSettingsInformation implements Serializable {
         Objects.equals(this.enableAccessCodeGeneratorMetadata, accountSettingsInformation.enableAccessCodeGeneratorMetadata) &&
         Objects.equals(this.enableAccountWideSearch, accountSettingsInformation.enableAccountWideSearch) &&
         Objects.equals(this.enableAccountWideSearchMetadata, accountSettingsInformation.enableAccountWideSearchMetadata) &&
+        Objects.equals(this.enableAdditionalAdvancedWebFormsFeatures, accountSettingsInformation.enableAdditionalAdvancedWebFormsFeatures) &&
+        Objects.equals(this.enableAdditionalAdvancedWebFormsFeaturesMetadata, accountSettingsInformation.enableAdditionalAdvancedWebFormsFeaturesMetadata) &&
         Objects.equals(this.enableAdmHealthcare, accountSettingsInformation.enableAdmHealthcare) &&
         Objects.equals(this.enableAdmHealthcareMetadata, accountSettingsInformation.enableAdmHealthcareMetadata) &&
         Objects.equals(this.enableAdvancedEnvelopesSearch, accountSettingsInformation.enableAdvancedEnvelopesSearch) &&
@@ -22998,8 +23093,6 @@ public class AccountSettingsInformation implements Serializable {
         Objects.equals(this.enableReservedDomainMetadata, accountSettingsInformation.enableReservedDomainMetadata) &&
         Objects.equals(this.enableResponsiveSigning, accountSettingsInformation.enableResponsiveSigning) &&
         Objects.equals(this.enableResponsiveSigningMetadata, accountSettingsInformation.enableResponsiveSigningMetadata) &&
-        Objects.equals(this.enableSaveAsEnvelopeCustomFieldInWebForms, accountSettingsInformation.enableSaveAsEnvelopeCustomFieldInWebForms) &&
-        Objects.equals(this.enableSaveAsEnvelopeCustomFieldInWebFormsMetadata, accountSettingsInformation.enableSaveAsEnvelopeCustomFieldInWebFormsMetadata) &&
         Objects.equals(this.enableScheduledRelease, accountSettingsInformation.enableScheduledRelease) &&
         Objects.equals(this.enableScheduledReleaseMetadata, accountSettingsInformation.enableScheduledReleaseMetadata) &&
         Objects.equals(this.enableSearchServiceAzureUri, accountSettingsInformation.enableSearchServiceAzureUri) &&
@@ -23320,7 +23413,7 @@ public class AccountSettingsInformation implements Serializable {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(accessCodeFormat, accountDateTimeFormat, accountDateTimeFormatMetadata, accountDefaultLanguage, accountDefaultLanguageMetadata, accountName, accountNameMetadata, accountNotification, accountUISettings, adoptSigConfig, adoptSigConfigMetadata, advancedCorrect, advancedCorrectMetadata, advancedSearchEnableTabField, advancedSearchEnableTabFieldMetadata, advancedSearchEnableTemplateIdField, advancedSearchEnableTemplateIdFieldMetadata, advancedSearchEnableTemplateNameField, advancedSearchEnableTemplateNameFieldMetadata, allowAccessCodeFormat, allowAccessCodeFormatMetadata, allowAccountManagementGranular, allowAccountManagementGranularMetadata, allowAccountMemberNameChange, allowAccountMemberNameChangeMetadata, allowACE, allowACEMetadata, allowAdvancedRecipientRoutingConditional, allowAdvancedRecipientRoutingConditionalMetadata, allowAgentNameEmailEdit, allowAgentNameEmailEditMetadata, allowAgreementActions, allowAgreementActionsMetadata, allowAgreementOrchestrations, allowAgreementOrchestrationsMetadata, allowAutoNavSettings, allowAutoNavSettingsMetadata, allowAutoTagging, allowAutoTaggingMetadata, allowBulkSend, allowBulkSendMetadata, allowCDWithdraw, allowCDWithdrawMetadata, allowConnectEnvelopeRemovedEvent, allowConnectHttpListenerConfigs, allowConnectIdentityVerificationUI, allowConnectOAuthUI, allowConnectSendFinishLater, allowConnectSendFinishLaterMetadata, allowConnectUnifiedPayloadUI, allowConsumerDisclosureOverride, allowConsumerDisclosureOverrideMetadata, allowDataDownload, allowDataDownloadMetadata, allowDelayedRouting, allowDelayedRoutingMetadata, allowDelegatedSigning, allowDelegatedSigningMetadata, allowDocGenDocuments, allowDocGenDocumentsMetadata, allowDocumentDisclosures, allowDocumentDisclosuresMetadata, allowDocumentsOnSignedEnvelopes, allowDocumentsOnSignedEnvelopesMetadata, allowDocumentVisibility, allowDocumentVisibilityMetadata, allowEditingEnvelopesOnBehalfOfOthers, allowEditingEnvelopesOnBehalfOfOthersMetadata, allowEHankoStamps, allowEHankoStampsMetadata, allowENoteEOriginal, allowENoteEOriginalMetadata, allowEnvelopeCorrect, allowEnvelopeCorrectMetadata, allowEnvelopeCustodyTransfer, allowEnvelopeCustodyTransferMetadata, allowEnvelopeCustomFields, allowEnvelopeCustomFieldsMetadata, allowEnvelopePublishReporting, allowEnvelopePublishReportingMetadata, allowEnvelopeReporting, allowEnvelopeReportingMetadata, allowExpression, allowExpressionMetadata, allowExpressSignerCertificate, allowExpressSignerCertificateMetadata, allowExtendedSendingResourceFile, allowExtendedSendingResourceFileMetadata, allowExternalLinkedAccounts, allowExternalLinkedAccountsMetadata, allowExternalSignaturePad, allowExternalSignaturePadMetadata, allowIDVForEUQualifiedSignatures, allowIDVForEUQualifiedSignaturesMetadata, allowIDVLevel1, allowIDVLevel1Metadata, allowIDVLevel1Trial, allowIDVLevel1TrialMetadata, allowIDVLevel2, allowIDVLevel2Metadata, allowIDVLevel3, allowIDVLevel3Metadata, allowIDVPlatform, allowIDVPlatformMetadata, allowInPerson, allowInPersonElectronicNotary, allowInPersonElectronicNotaryMetadata, allowInPersonMetadata, allowManagedStamps, allowManagedStampsMetadata, allowManagingEnvelopesOnBehalfOfOthers, allowManagingEnvelopesOnBehalfOfOthersMetadata, allowMarkup, allowMarkupMetadata, allowMemberTimeZone, allowMemberTimeZoneMetadata, allowMergeFields, allowMergeFieldsMetadata, allowMultipleBrandProfiles, allowMultipleBrandProfilesMetadata, allowMultipleSignerAttachments, allowMultipleSignerAttachmentsMetadata, allowNonUSPhoneAuth, allowNonUSPhoneAuthMetadata, allowOcrOfEnvelopeDocuments, allowOcrOfEnvelopeDocumentsMetadata, allowOfflineSigning, allowOfflineSigningMetadata, allowOpenTrustSignerCertificate, allowOpenTrustSignerCertificateMetadata, allowOrganizationBranding, allowOrganizationBrandingMetadata, allowOrganizationDocusignMonitor, allowOrganizationDocusignMonitorFree, allowOrganizationDocusignMonitorFreeMetadata, allowOrganizationDocusignMonitorMetadata, allowOrganizationDomainUserManagement, allowOrganizationDomainUserManagementMetadata, allowOrganizations, allowOrganizationsMetadata, allowOrganizationSsoManagement, allowOrganizationSsoManagementMetadata, allowOrganizationToUseInPersonElectronicNotary, allowOrganizationToUseInPersonElectronicNotaryMetadata, allowOrganizationToUseRemoteNotary, allowOrganizationToUseRemoteNotaryMetadata, allowOrganizationToUseThirdPartyElectronicNotary, allowOrganizationToUseThirdPartyElectronicNotaryMetadata, allowParticipantRecipientType, allowParticipantRecipientTypeMetadata, allowPaymentProcessing, allowPaymentProcessingMetadata, allowPendingDestinationUrlEdition, allowPendingDestinationUrlEditionMetadata, allowPerformanceAnalytics, allowPerformanceAnalyticsMetadata, allowPhoneAuthentication, allowPhoneAuthenticationMetadata, allowPhoneAuthOverride, allowPhoneAuthOverrideMetadata, allowPrivateSigningGroups, allowPrivateSigningGroupsMetadata, allowRecipientConnect, allowRecipientConnectMetadata, allowReminders, allowRemindersMetadata, allowRemoteNotary, allowRemoteNotaryMetadata, allowResourceFileBranding, allowResourceFileBrandingMetadata, allowSafeBioPharmaSignerCertificate, allowSafeBioPharmaSignerCertificateMetadata, allowScheduledSending, allowScheduledSendingMetadata, allowSecurityAppliance, allowSecurityApplianceMetadata, allowSendingEnvelopesOnBehalfOfOthers, allowSendingEnvelopesOnBehalfOfOthersMetadata, allowSendToCertifiedDelivery, allowSendToCertifiedDeliveryMetadata, allowSendToIntermediary, allowSendToIntermediaryMetadata, allowServerTemplates, allowServerTemplatesMetadata, allowSetEmbeddedRecipientStartURL, allowSetEmbeddedRecipientStartURLMetadata, allowSharedTabs, allowSharedTabsMetadata, allowSignatureStamps, allowSignatureStampsMetadata, allowSignDocumentFromHomePage, allowSignDocumentFromHomePageMetadata, allowSignerReassign, allowSignerReassignMetadata, allowSignerReassignOverride, allowSignerReassignOverrideMetadata, allowSigningExtensions, allowSigningExtensionsMetadata, allowSigningGroups, allowSigningGroupsMetadata, allowSigningInsights, allowSigningInsightsMetadata, allowSigningRadioDeselect, allowSigningRadioDeselectMetadata, allowSignNow, allowSignNowMetadata, allowSMSDelivery, allowSMSDeliveryMetadata, allowSocialIdLogin, allowSocialIdLoginMetadata, allowSupplementalDocuments, allowSupplementalDocumentsMetadata, allowThirdPartyElectronicNotary, allowThirdPartyElectronicNotaryMetadata, allowTransactionsWorkspace, allowTransactionsWorkspaceMetadata, allowTransactionsWorkspaceOriginal, allowTransactionsWorkspaceOriginalMetadata, allowUsersToAccessDirectory, allowUsersToAccessDirectoryMetadata, allowValueInsights, allowValueInsightsMetadata, allowWebForms, allowWebFormsMetadata, allowWhatsAppDelivery, allowWhatsAppDeliveryMetadata, anchorPopulationScope, anchorPopulationScopeMetadata, anchorTagVersionedPlacementEnabled, anchorTagVersionedPlacementMetadataEnabled, attachCompletedEnvelope, attachCompletedEnvelopeMetadata, authenticationCheck, authenticationCheckMetadata, autoNavRule, autoNavRuleMetadata, autoProvisionSignerAccount, autoProvisionSignerAccountMetadata, bccEmailArchive, bccEmailArchiveMetadata, betaSwitchConfiguration, betaSwitchConfigurationMetadata, billingAddress, billingAddressMetadata, bulkSend, bulkSendActionResendLimit, bulkSendMaxCopiesInBatch, bulkSendMaxUnprocessedEnvelopesCount, bulkSendMetadata, canSelfBrandSend, canSelfBrandSendMetadata, canSelfBrandSign, canSelfBrandSignMetadata, canUseSalesforceOAuth, canUseSalesforceOAuthMetadata, captureVoiceRecording, captureVoiceRecordingMetadata, cfr21SimplifiedSigningEnabled, cfr21SimplifiedSigningEnabledMetadata, cfrUseWideImage, cfrUseWideImageMetadata, checkForMultipleAdminsOnAccount, checkForMultipleAdminsOnAccountMetadata, chromeSignatureEnabled, chromeSignatureEnabledMetadata, commentEmailShowMessageText, commentEmailShowMessageTextMetadata, commentsAllowEnvelopeOverride, commentsAllowEnvelopeOverrideMetadata, conditionalFieldsEnabled, conditionalFieldsEnabledMetadata, consumerDisclosureFrequency, consumerDisclosureFrequencyMetadata, convertPdfFields, convertPdfFieldsMetadata, dataPopulationScope, dataPopulationScopeMetadata, defaultToAdvancedEnvelopesFilterForm, defaultToAdvancedEnvelopesFilterFormMetadata, disableAutoTemplateMatching, disableAutoTemplateMatchingMetadata, disableBulkSendRecipientLimit, disableBulkSendRecipientLimitMetaData, disableMobileApp, disableMobileAppMetadata, disableMobilePushNotifications, disableMobilePushNotificationsMetadata, disableMobileSending, disableMobileSendingMetadata, disableMultipleSessions, disableMultipleSessionsMetadata, disablePurgeNotificationsForSenderMetadata, disableSignerCertView, disableSignerCertViewMetadata, disableSignerHistoryView, disableSignerHistoryViewMetadata, disableStyleSignature, disableStyleSignatureMetadata, disableUploadSignature, disableUploadSignatureMetadata, disableUserSharing, disableUserSharingMetadata, displayBetaSwitch, displayBetaSwitchMetadata, documentConversionRestrictions, documentConversionRestrictionsMetadata, documentRetention, documentRetentionMetadata, documentRetentionPurgeTabs, documentVisibility, documentVisibilityMetadata, draftEnvelopeRetention, draftEnvelopeRetentionMetadata, dssEnableProvisioningPenConfigurationRadminOption, dssEnableSignatureTypeCustomTagRadminRadminOption, dssSIGN28411EnableLeavePagePromptRadminOption, dssSIGN29182SlideUpBarRadminOption, emailTemplateVersion, emailTemplateVersionMetadata, enableAccessCodeGenerator, enableAccessCodeGeneratorMetadata, enableAccountWideSearch, enableAccountWideSearchMetadata, enableAdmHealthcare, enableAdmHealthcareMetadata, enableAdvancedEnvelopesSearch, enableAdvancedEnvelopesSearchMetadata, enableAdvancedPayments, enableAdvancedPaymentsMetadata, enableAdvancedPowerForms, enableAdvancedPowerFormsMetadata, enableAdvancedSearch, enableAdvancedSearchMetadata, enableAgreementActionsForCLM, enableAgreementActionsForCLMMetadata, enableAgreementActionsForESign, enableAgreementActionsForESignMetadata, enableAutoNav, enableAutoNavMetadata, enableBccDummyLink, enableBccDummyLinkMetadata, enableCalculatedFields, enableCalculatedFieldsMetadata, enableClickPlus, enableClickPlusConditionalContent, enableClickPlusConditionalContentMetaData, enableClickPlusCustomFields, enableClickPlusCustomFieldsMetaData, enableClickPlusCustomStyle, enableClickPlusCustomStyleMetaData, enableClickPlusDynamicContent, enableClickPlusDynamicContentMetaData, enableClickPlusMetaData, enableClickwraps, enableClickwrapsMetadata, enableCombinedPDFDownloadForSBS, enableCommentsHistoryDownloadInSigning, enableCommentsHistoryDownloadInSigningMetadata, enableContactSuggestions, enableContactSuggestionsMetadata, enableContentSearch, enableContentSearchMetadata, enableCustomerSatisfactionMetricTracking, enableCustomerSatisfactionMetricTrackingMetadata, enableDataVerificationExtensions, enableDataVerificationExtensionsMetadata, enableDSigEUAdvancedPens, enableDSigEUAdvancedPensMetadata, enableDSigExpressPens, enableDSigExpressPensMetadata, enableDSigIDCheckForAESPens, enableDSigIDCheckForAESPensMetadata, enableDSigIDCheckInPersonForQESPens, enableDSigIDCheckInPersonForQESPensMetadata, enableDSigIDCheckRemoteForQESPens, enableDSigIDCheckRemoteForQESPensMetadata, enableDSigIDVerificationPens, enableDSigIDVerificationPensMetadata, enableDSigIDVerificationPremierPens, enableDSigIDVerificationPremierPensMetadata, enableDSPro, enableDSProMetadata, enableEnforceTlsEmailsSettingMetadata, enableEnvelopeStampingByAccountAdmin, enableEnvelopeStampingByAccountAdminMetadata, enableEnvelopeStampingByDSAdmin, enableEnvelopeStampingByDSAdminMetadata, enableESignAPIHourlyLimitManagement, enableESignAPIHourlyLimitManagementMetadata, enableEsignCommunities, enableEsignCommunitiesMetadata, enableIDFxAccountlessSMSAuthForPart11, enableIDFxAccountlessSMSAuthForPart11Metadata, enableIDFxIntuitKBA, enableIDFxIntuitKBAMetadata, enableIDFxPhoneAuthentication, enableIDFxPhoneAuthenticationMetadata, enableIdfxPhoneAuthSignatureAuthStatus, enableIdfxPhoneAuthSignatureAuthStatusMetadata, enableInboxBrowseViewsPoweredByElasticSearch, enableInboxBrowseViewsPoweredByElasticSearchMetadata, enableInboxRelevanceSort, enableInboxRelevanceSortMetadata, enableInBrowserEditor, enableInBrowserEditorMetadata, enableKeyTermsSuggestionsByDocumentType, enableKeyTermsSuggestionsByDocumentTypeMetadata, enableLargeFileSupport, enableLargeFileSupportMetadata, enableMultiUserRepositoryFeatures, enableMultiUserRepositoryFeaturesMetadata, enableParticipantRecipientSettingMetadata, enablePaymentProcessing, enablePaymentProcessingMetadata, enablePDFAConversion, enablePDFAConversionMetadata, enablePowerForm, enablePowerFormDirect, enablePowerFormDirectMetadata, enablePowerFormMetadata, enablePremiumDataVerificationExtensions, enablePremiumDataVerificationExtensionsMetadata, enableRecipientDomainValidation, enableRecipientDomainValidationMetadata, enableRecipientMayProvidePhoneNumber, enableRecipientMayProvidePhoneNumberMetadata, enableReportLinks, enableReportLinksMetadata, enableRequireSignOnPaper, enableRequireSignOnPaperMetadata, enableReservedDomain, enableReservedDomainMetadata, enableResponsiveSigning, enableResponsiveSigningMetadata, enableSaveAsEnvelopeCustomFieldInWebForms, enableSaveAsEnvelopeCustomFieldInWebFormsMetadata, enableScheduledRelease, enableScheduledReleaseMetadata, enableSearchServiceAzureUri, enableSearchServiceAzureUriMetadata, enableSearchSiteSpecificApi, enableSearchSiteSpecificApiMetadata, enableSendingTagsFontSettings, enableSendingTagsFontSettingsMetadata, enableSendToAgent, enableSendToAgentMetadata, enableSendToIntermediary, enableSendToIntermediaryMetadata, enableSendToManage, enableSendToManageMetadata, enableSequentialSigningAPI, enableSequentialSigningAPIMetadata, enableSequentialSigningUI, enableSequentialSigningUIMetadata, enableSignerAttachments, enableSignerAttachmentsMetadata, enableSigningExtensionComments, enableSigningExtensionCommentsMetadata, enableSigningExtensionConversations, enableSigningExtensionConversationsMetadata, enableSigningOrderSettingsForAccount, enableSigningOrderSettingsForAccountMetadata, enableSignOnPaper, enableSignOnPaperMetadata, enableSignOnPaperOverride, enableSignOnPaperOverrideMetadata, enableSignWithNotary, enableSignWithNotaryMetadata, enableSmartContracts, enableSmartContractsMetadata, enableSMSAuthentication, enableSMSAuthenticationMetadata, enableSMSDeliveryAdditionalNotification, enableSMSDeliveryAdditionalNotificationMetadata, enableSMSDeliveryPrimary, enableSocialIdLogin, enableSocialIdLoginMetadata, enableStrikeThrough, enableStrikeThroughMetadata, enableTransactionPoint, enableTransactionPointMetadata, enableUnifiedRepository, enableUnifiedRepositoryMetadata, enableVaulting, enableVaultingMetadata, enableWebFormsRuntimeAPIs, enableWebFormsRuntimeAPIsMetadata, enableWebFormsSeparateUserPermissions, enableWebFormsSeparateUserPermissionsMetadata, enableWitnessing, enableWitnessingMetadata, enforceTemplateNameUniqueness, enforceTemplateNameUniquenessMetadata, enforceTlsEmails, enforceTlsEmailsMetadata, envelopeIntegrationAllowed, envelopeIntegrationAllowedMetadata, envelopeIntegrationEnabled, envelopeIntegrationEnabledMetadata, envelopeLimitsTotalDocumentSizeAllowedInMB, envelopeLimitsTotalDocumentSizeAllowedInMBEnabled, envelopeLimitsTotalDocumentSizeAllowedInMBEnabledMetadata, envelopeLimitsTotalDocumentSizeAllowedInMBMetadata, envelopeSearchMode, envelopeSearchModeMetadata, envelopeStampingDefaultValue, envelopeStampingDefaultValueMetadata, exitPrompt, exitPromptMetadata, expressSend, expressSendAllowTabs, expressSendAllowTabsMetadata, expressSendMetadata, externalDocumentSources, externalSignaturePadType, externalSignaturePadTypeMetadata, faxOutEnabled, faxOutEnabledMetadata, finishReminder, finishReminderMetadata, forbidAddingUserStamps, forbidAddingUserStampsMetadata, guidedFormsHtmlAllowed, guidedFormsHtmlAllowedMetadata, guidedFormsHtmlConversionPolicy, guidedFormsHtmlConversionPolicyMetadata, hasRecipientConnectClaimedDomain, hideAccountAddressInCoC, hideAccountAddressInCoCMetadata, hidePricing, hidePricingMetadata, idCheckConfigurations, idCheckExpire, idCheckExpireDays, idCheckExpireDaysMetadata, idCheckExpireMetadata, idCheckExpireMinutes, idCheckExpireMinutesMetadata, idCheckRequired, idCheckRequiredMetadata, identityVerification, identityVerificationMetadata, idfxKBAAuthenticationOverride, idfxKBAAuthenticationOverrideMetadata, idfxPhoneAuthenticationOverride, idfxPhoneAuthenticationOverrideMetadata, ignoreErrorIfAnchorTabNotFound, ignoreErrorIfAnchorTabNotFoundMetadataEnabled, inPersonIDCheckQuestion, inPersonIDCheckQuestionMetadata, inPersonSigningEnabled, inPersonSigningEnabledMetadata, inSessionEnabled, inSessionEnabledMetadata, inSessionSuppressEmails, inSessionSuppressEmailsMetadata, isConnectDocumentFieldsEnabled, isvOemEmbed, isvOemEmbedMetaData, linkedExternalPrimaryAccounts, maximumSigningGroups, maximumSigningGroupsMetadata, maximumUsersPerSigningGroup, maximumUsersPerSigningGroupMetadata, maxNumberOfCustomStamps, mergeMixedModeResults, mergeMixedModeResultsMetadata, mobileSessionTimeout, mobileSessionTimeoutMetadata, numberOfActiveCustomStamps, optInMobileSigningV02, optInMobileSigningV02Metadata, optInUniversalSignatures, optOutAutoNavTextAndTabColorUpdates, optOutAutoNavTextAndTabColorUpdatesMetadata, optOutNewPlatformSeal, optOutNewPlatformSealPlatformMetadata, pdfMaxChunkedUploadPartSize, pdfMaxChunkedUploadPartSizeMetadata, pdfMaxChunkedUploadTotalSize, pdfMaxChunkedUploadTotalSizeMetadata, pdfMaxIndividualUploadSize, pdfMaxIndividualUploadSizeMetadata, phoneAuthRecipientMayProvidePhoneNumber, phoneAuthRecipientMayProvidePhoneNumberMetadata, pkiSignDownloadedPDFDocs, pkiSignDownloadedPDFDocsMetadata, readOnlyMode, readOnlyModeMetadata, recipientsCanSignOffline, recipientsCanSignOfflineMetadata, recipientSigningAutoNavigationControl, recipientSigningAutoNavigationControlMetadata, require21CFRpt11Compliance, require21CFRpt11ComplianceMetadata, requireDeclineReason, requireDeclineReasonMetadata, requireExternalUserManagement, requireExternalUserManagementMetadata, requireSignerCertificateType, requireSignerCertificateTypeMetadata, rsaVeridAccountName, rsaVeridPassword, rsaVeridRuleset, rsaVeridUserId, sbsTransactionLevel, selfSignedRecipientEmailDocument, selfSignedRecipientEmailDocumentMetadata, selfSignedRecipientEmailDocumentUserOverride, selfSignedRecipientEmailDocumentUserOverrideMetadata, senderCanSignInEachLocation, senderCanSignInEachLocationMetadata, senderMustAuthenticateSigning, senderMustAuthenticateSigningMetadata, sendingTagsFontColor, sendingTagsFontColorMetadata, sendingTagsFontName, sendingTagsFontNameMetadata, sendingTagsFontSize, sendingTagsFontSizeMetadata, sendLockoutRecipientNotification, sendLockoutRecipientNotificationMetadata, sendToCertifiedDeliveryEnabled, sendToCertifiedDeliveryEnabledMetadata, sessionTimeout, sessionTimeoutMetadata, setRecipEmailLang, setRecipEmailLangMetadata, setRecipSignLang, setRecipSignLangMetadata, sharedTemplateFolders, sharedTemplateFoldersMetadata, showCompleteDialogInEmbeddedSession, showCompleteDialogInEmbeddedSessionMetadata, showConditionalRoutingOnSend, showConditionalRoutingOnSendMetadata, showInitialConditionalFields, showInitialConditionalFieldsMetadata, showLocalizedWatermarks, showLocalizedWatermarksMetadata, showMaskedFieldsWhenDownloadingDocumentAsSender, showMaskedFieldsWhenDownloadingDocumentAsSenderMetadata, showTutorials, showTutorialsMetadata, signatureProviders, signatureProvidersMetadata, signDateFormat, signDateFormatMetadata, signDateTimeAccountLanguageOverride, signDateTimeAccountLanguageOverrideMetadata, signDateTimeAccountTimezoneOverride, signDateTimeAccountTimezoneOverrideMetadata, signerAttachCertificateToEnvelopePDF, signerAttachCertificateToEnvelopePDFMetadata, signerAttachConcat, signerAttachConcatMetadata, signerCanCreateAccount, signerCanCreateAccountMetadata, signerCanSignOnMobile, signerCanSignOnMobileMetadata, signerInSessionUseEnvelopeCompleteEmail, signerInSessionUseEnvelopeCompleteEmailMetadata, signerLoginRequirements, signerLoginRequirementsMetadata, signerMustHaveAccount, signerMustHaveAccountMetadata, signerMustLoginToSign, signerMustLoginToSignMetadata, signerShowSecureFieldInitialValues, signerShowSecureFieldInitialValuesMetadata, signingSessionTimeout, signingSessionTimeoutMetadata, signingUiVersion, signingUiVersionMetadata, signTimeFormat, signTimeFormatMetadata, signTimeShowAmPm, signTimeShowAmPmMetadata, simplifiedSendingEnabled, simplifiedSendingEnabledMetadata, singleSignOnEnabled, singleSignOnEnabledMetadata, skipAuthCompletedEnvelopes, skipAuthCompletedEnvelopesMetadata, socialIdRecipAuth, socialIdRecipAuthMetadata, specifyDocumentVisibility, specifyDocumentVisibilityMetadata, startInAdvancedCorrect, startInAdvancedCorrectMetadata, supplementalDocumentsMustAccept, supplementalDocumentsMustAcceptMetadata, supplementalDocumentsMustRead, supplementalDocumentsMustReadMetadata, supplementalDocumentsMustView, supplementalDocumentsMustViewMetadata, suppressCertificateEnforcement, suppressCertificateEnforcementMetadata, tabAccountSettings, timezoneOffsetAPI, timezoneOffsetAPIMetadata, timezoneOffsetUI, timezoneOffsetUIMetadata, universalSignatureOptIn, useAccountLevelEmail, useAccountLevelEmailMetadata, useConsumerDisclosure, useConsumerDisclosureMetadata, useConsumerDisclosureWithinAccount, useConsumerDisclosureWithinAccountMetadata, useDerivedKeys, useDerivedKeysMetadata, useDocuSignExpressSignerCertificate, useDocuSignExpressSignerCertificateMetadata, useEnvelopeSearchMixedMode, useEnvelopeSearchMixedModeMetadata, useMultiAppGroupsData, useMultiAppGroupsDataMetadata, useNewBlobForPdf, useNewBlobForPdfMetadata, useNewEnvelopeSearch, useNewEnvelopeSearchMetadata, useNewEnvelopeSearchOnlyWhenSearchingAfterDate, useNewEnvelopeSearchOnlyWhenSearchingAfterDateMetadata, useNewEnvelopeSearchOnlyWithSearchTerm, useNewEnvelopeSearchOnlyWithSearchTermMetadata, useSAFESignerCertificates, useSAFESignerCertificatesMetadata, usesAPI, usesAPIMetadata, useSignatureProviderPlatform, useSignatureProviderPlatformMetadata, useSmartContractsV1, validationsAllowed, validationsAllowedMetadata, validationsBrand, validationsBrandMetadata, validationsCadence, validationsCadenceMetadata, validationsEnabled, validationsEnabledMetadata, validationsReport, validationsReportMetadata, waterMarkEnabled, waterMarkEnabledMetadata, writeReminderToEnvelopeHistory, writeReminderToEnvelopeHistoryMetadata, wurflMinAllowableScreenSize, wurflMinAllowableScreenSizeMetadata);
+    return Objects.hash(accessCodeFormat, accountDateTimeFormat, accountDateTimeFormatMetadata, accountDefaultLanguage, accountDefaultLanguageMetadata, accountName, accountNameMetadata, accountNotification, accountUISettings, adoptSigConfig, adoptSigConfigMetadata, advancedCorrect, advancedCorrectMetadata, advancedSearchEnableTabField, advancedSearchEnableTabFieldMetadata, advancedSearchEnableTemplateIdField, advancedSearchEnableTemplateIdFieldMetadata, advancedSearchEnableTemplateNameField, advancedSearchEnableTemplateNameFieldMetadata, allowAccessCodeFormat, allowAccessCodeFormatMetadata, allowAccountManagementGranular, allowAccountManagementGranularMetadata, allowAccountMemberNameChange, allowAccountMemberNameChangeMetadata, allowACE, allowACEMetadata, allowAdvancedRecipientRoutingConditional, allowAdvancedRecipientRoutingConditionalMetadata, allowAgentNameEmailEdit, allowAgentNameEmailEditMetadata, allowAgreementActions, allowAgreementActionsMetadata, allowAgreementOrchestrations, allowAgreementOrchestrationsMetadata, allowAutoNavSettings, allowAutoNavSettingsMetadata, allowAutoTagging, allowAutoTaggingMetadata, allowBulkSend, allowBulkSendMetadata, allowCDWithdraw, allowCDWithdrawMetadata, allowConnectEnvelopeRemovedEvent, allowConnectHttpListenerConfigs, allowConnectIdentityVerificationUI, allowConnectOAuthUI, allowConnectSendFinishLater, allowConnectSendFinishLaterMetadata, allowConnectUnifiedPayloadUI, allowConsumerDisclosureOverride, allowConsumerDisclosureOverrideMetadata, allowDataDownload, allowDataDownloadMetadata, allowDelayedRouting, allowDelayedRoutingMetadata, allowDelegatedSigning, allowDelegatedSigningMetadata, allowDocGenDocuments, allowDocGenDocumentsMetadata, allowDocumentDisclosures, allowDocumentDisclosuresMetadata, allowDocumentsOnSignedEnvelopes, allowDocumentsOnSignedEnvelopesMetadata, allowDocumentVisibility, allowDocumentVisibilityMetadata, allowEditingEnvelopesOnBehalfOfOthers, allowEditingEnvelopesOnBehalfOfOthersMetadata, allowEHankoStamps, allowEHankoStampsMetadata, allowENoteEOriginal, allowENoteEOriginalMetadata, allowEnvelopeCorrect, allowEnvelopeCorrectMetadata, allowEnvelopeCustodyTransfer, allowEnvelopeCustodyTransferMetadata, allowEnvelopeCustomFields, allowEnvelopeCustomFieldsMetadata, allowEnvelopePublishReporting, allowEnvelopePublishReportingMetadata, allowEnvelopeReporting, allowEnvelopeReportingMetadata, allowExpression, allowExpressionMetadata, allowExpressSignerCertificate, allowExpressSignerCertificateMetadata, allowExtendedSendingResourceFile, allowExtendedSendingResourceFileMetadata, allowExternalLinkedAccounts, allowExternalLinkedAccountsMetadata, allowExternalSignaturePad, allowExternalSignaturePadMetadata, allowIDVForEUQualifiedSignatures, allowIDVForEUQualifiedSignaturesMetadata, allowIDVLevel1, allowIDVLevel1Metadata, allowIDVLevel1Trial, allowIDVLevel1TrialMetadata, allowIDVLevel2, allowIDVLevel2Metadata, allowIDVLevel3, allowIDVLevel3Metadata, allowIDVPlatform, allowIDVPlatformMetadata, allowInPerson, allowInPersonElectronicNotary, allowInPersonElectronicNotaryMetadata, allowInPersonMetadata, allowManagedStamps, allowManagedStampsMetadata, allowManagingEnvelopesOnBehalfOfOthers, allowManagingEnvelopesOnBehalfOfOthersMetadata, allowMarkup, allowMarkupMetadata, allowMemberTimeZone, allowMemberTimeZoneMetadata, allowMergeFields, allowMergeFieldsMetadata, allowMultipleBrandProfiles, allowMultipleBrandProfilesMetadata, allowMultipleSignerAttachments, allowMultipleSignerAttachmentsMetadata, allowNonUSPhoneAuth, allowNonUSPhoneAuthMetadata, allowOcrOfEnvelopeDocuments, allowOcrOfEnvelopeDocumentsMetadata, allowOfflineSigning, allowOfflineSigningMetadata, allowOpenTrustSignerCertificate, allowOpenTrustSignerCertificateMetadata, allowOrganizationBranding, allowOrganizationBrandingMetadata, allowOrganizationDocusignMonitor, allowOrganizationDocusignMonitorFree, allowOrganizationDocusignMonitorFreeMetadata, allowOrganizationDocusignMonitorMetadata, allowOrganizationDomainUserManagement, allowOrganizationDomainUserManagementMetadata, allowOrganizations, allowOrganizationsMetadata, allowOrganizationSsoManagement, allowOrganizationSsoManagementMetadata, allowOrganizationToUseInPersonElectronicNotary, allowOrganizationToUseInPersonElectronicNotaryMetadata, allowOrganizationToUseRemoteNotary, allowOrganizationToUseRemoteNotaryMetadata, allowOrganizationToUseThirdPartyElectronicNotary, allowOrganizationToUseThirdPartyElectronicNotaryMetadata, allowParticipantRecipientType, allowParticipantRecipientTypeMetadata, allowPaymentProcessing, allowPaymentProcessingMetadata, allowPendingDestinationUrlEdition, allowPendingDestinationUrlEditionMetadata, allowPerformanceAnalytics, allowPerformanceAnalyticsMetadata, allowPhoneAuthentication, allowPhoneAuthenticationMetadata, allowPhoneAuthOverride, allowPhoneAuthOverrideMetadata, allowPrivateSigningGroups, allowPrivateSigningGroupsMetadata, allowRecipientConnect, allowRecipientConnectMetadata, allowReminders, allowRemindersMetadata, allowRemoteNotary, allowRemoteNotaryMetadata, allowResourceFileBranding, allowResourceFileBrandingMetadata, allowSafeBioPharmaSignerCertificate, allowSafeBioPharmaSignerCertificateMetadata, allowScheduledSending, allowScheduledSendingMetadata, allowSecurityAppliance, allowSecurityApplianceMetadata, allowSendingEnvelopesOnBehalfOfOthers, allowSendingEnvelopesOnBehalfOfOthersMetadata, allowSendToCertifiedDelivery, allowSendToCertifiedDeliveryMetadata, allowSendToIntermediary, allowSendToIntermediaryMetadata, allowServerTemplates, allowServerTemplatesMetadata, allowSetEmbeddedRecipientStartURL, allowSetEmbeddedRecipientStartURLMetadata, allowSharedTabs, allowSharedTabsMetadata, allowSignatureStamps, allowSignatureStampsMetadata, allowSignDocumentFromHomePage, allowSignDocumentFromHomePageMetadata, allowSignerReassign, allowSignerReassignMetadata, allowSignerReassignOverride, allowSignerReassignOverrideMetadata, allowSigningExtensions, allowSigningExtensionsMetadata, allowSigningGroups, allowSigningGroupsMetadata, allowSigningInsights, allowSigningInsightsMetadata, allowSigningRadioDeselect, allowSigningRadioDeselectMetadata, allowSignNow, allowSignNowMetadata, allowSMSDelivery, allowSMSDeliveryMetadata, allowSocialIdLogin, allowSocialIdLoginMetadata, allowSupplementalDocuments, allowSupplementalDocumentsMetadata, allowThirdPartyElectronicNotary, allowThirdPartyElectronicNotaryMetadata, allowTransactionsWorkspace, allowTransactionsWorkspaceMetadata, allowTransactionsWorkspaceOriginal, allowTransactionsWorkspaceOriginalMetadata, allowUsersToAccessDirectory, allowUsersToAccessDirectoryMetadata, allowValueInsights, allowValueInsightsMetadata, allowWebForms, allowWebFormsMetadata, allowWhatsAppDelivery, allowWhatsAppDeliveryMetadata, anchorPopulationScope, anchorPopulationScopeMetadata, anchorTagVersionedPlacementEnabled, anchorTagVersionedPlacementMetadataEnabled, attachCompletedEnvelope, attachCompletedEnvelopeMetadata, authenticationCheck, authenticationCheckMetadata, autoNavRule, autoNavRuleMetadata, autoProvisionSignerAccount, autoProvisionSignerAccountMetadata, bccEmailArchive, bccEmailArchiveMetadata, betaSwitchConfiguration, betaSwitchConfigurationMetadata, billingAddress, billingAddressMetadata, bulkSend, bulkSendActionResendLimit, bulkSendMaxCopiesInBatch, bulkSendMaxUnprocessedEnvelopesCount, bulkSendMetadata, canSelfBrandSend, canSelfBrandSendMetadata, canSelfBrandSign, canSelfBrandSignMetadata, canUseSalesforceOAuth, canUseSalesforceOAuthMetadata, captureVoiceRecording, captureVoiceRecordingMetadata, cfr21SimplifiedSigningEnabled, cfr21SimplifiedSigningEnabledMetadata, cfrUseWideImage, cfrUseWideImageMetadata, checkForMultipleAdminsOnAccount, checkForMultipleAdminsOnAccountMetadata, chromeSignatureEnabled, chromeSignatureEnabledMetadata, commentEmailShowMessageText, commentEmailShowMessageTextMetadata, commentsAllowEnvelopeOverride, commentsAllowEnvelopeOverrideMetadata, conditionalFieldsEnabled, conditionalFieldsEnabledMetadata, consumerDisclosureFrequency, consumerDisclosureFrequencyMetadata, convertPdfFields, convertPdfFieldsMetadata, dataPopulationScope, dataPopulationScopeMetadata, defaultSigningResponsiveView, defaultSigningResponsiveViewMetadata, defaultToAdvancedEnvelopesFilterForm, defaultToAdvancedEnvelopesFilterFormMetadata, disableAutoTemplateMatching, disableAutoTemplateMatchingMetadata, disableBulkSendRecipientLimit, disableBulkSendRecipientLimitMetaData, disableMobileApp, disableMobileAppMetadata, disableMobilePushNotifications, disableMobilePushNotificationsMetadata, disableMobileSending, disableMobileSendingMetadata, disableMultipleSessions, disableMultipleSessionsMetadata, disablePurgeNotificationsForSenderMetadata, disableSignerCertView, disableSignerCertViewMetadata, disableSignerHistoryView, disableSignerHistoryViewMetadata, disableStyleSignature, disableStyleSignatureMetadata, disableUploadSignature, disableUploadSignatureMetadata, disableUserSharing, disableUserSharingMetadata, displayBetaSwitch, displayBetaSwitchMetadata, documentConversionRestrictions, documentConversionRestrictionsMetadata, documentRetention, documentRetentionMetadata, documentRetentionPurgeTabs, documentVisibility, documentVisibilityMetadata, draftEnvelopeRetention, draftEnvelopeRetentionMetadata, dssEnableProvisioningPenConfigurationRadminOption, dssEnableSignatureTypeCustomTagRadminRadminOption, dssSCOREFDN196RebrandDocuSignIsNotAVerb, dssSIGN28411EnableLeavePagePromptRadminOption, dssSIGN29182SlideUpBarRadminOption, emailTemplateVersion, emailTemplateVersionMetadata, enableAccessCodeGenerator, enableAccessCodeGeneratorMetadata, enableAccountWideSearch, enableAccountWideSearchMetadata, enableAdditionalAdvancedWebFormsFeatures, enableAdditionalAdvancedWebFormsFeaturesMetadata, enableAdmHealthcare, enableAdmHealthcareMetadata, enableAdvancedEnvelopesSearch, enableAdvancedEnvelopesSearchMetadata, enableAdvancedPayments, enableAdvancedPaymentsMetadata, enableAdvancedPowerForms, enableAdvancedPowerFormsMetadata, enableAdvancedSearch, enableAdvancedSearchMetadata, enableAgreementActionsForCLM, enableAgreementActionsForCLMMetadata, enableAgreementActionsForESign, enableAgreementActionsForESignMetadata, enableAutoNav, enableAutoNavMetadata, enableBccDummyLink, enableBccDummyLinkMetadata, enableCalculatedFields, enableCalculatedFieldsMetadata, enableClickPlus, enableClickPlusConditionalContent, enableClickPlusConditionalContentMetaData, enableClickPlusCustomFields, enableClickPlusCustomFieldsMetaData, enableClickPlusCustomStyle, enableClickPlusCustomStyleMetaData, enableClickPlusDynamicContent, enableClickPlusDynamicContentMetaData, enableClickPlusMetaData, enableClickwraps, enableClickwrapsMetadata, enableCombinedPDFDownloadForSBS, enableCommentsHistoryDownloadInSigning, enableCommentsHistoryDownloadInSigningMetadata, enableContactSuggestions, enableContactSuggestionsMetadata, enableContentSearch, enableContentSearchMetadata, enableCustomerSatisfactionMetricTracking, enableCustomerSatisfactionMetricTrackingMetadata, enableDataVerificationExtensions, enableDataVerificationExtensionsMetadata, enableDSigEUAdvancedPens, enableDSigEUAdvancedPensMetadata, enableDSigExpressPens, enableDSigExpressPensMetadata, enableDSigIDCheckForAESPens, enableDSigIDCheckForAESPensMetadata, enableDSigIDCheckInPersonForQESPens, enableDSigIDCheckInPersonForQESPensMetadata, enableDSigIDCheckRemoteForQESPens, enableDSigIDCheckRemoteForQESPensMetadata, enableDSigIDVerificationPens, enableDSigIDVerificationPensMetadata, enableDSigIDVerificationPremierPens, enableDSigIDVerificationPremierPensMetadata, enableDSPro, enableDSProMetadata, enableEnforceTlsEmailsSettingMetadata, enableEnvelopeStampingByAccountAdmin, enableEnvelopeStampingByAccountAdminMetadata, enableEnvelopeStampingByDSAdmin, enableEnvelopeStampingByDSAdminMetadata, enableESignAPIHourlyLimitManagement, enableESignAPIHourlyLimitManagementMetadata, enableEsignCommunities, enableEsignCommunitiesMetadata, enableIDFxAccountlessSMSAuthForPart11, enableIDFxAccountlessSMSAuthForPart11Metadata, enableIDFxIntuitKBA, enableIDFxIntuitKBAMetadata, enableIDFxPhoneAuthentication, enableIDFxPhoneAuthenticationMetadata, enableIdfxPhoneAuthSignatureAuthStatus, enableIdfxPhoneAuthSignatureAuthStatusMetadata, enableInboxBrowseViewsPoweredByElasticSearch, enableInboxBrowseViewsPoweredByElasticSearchMetadata, enableInboxRelevanceSort, enableInboxRelevanceSortMetadata, enableInBrowserEditor, enableInBrowserEditorMetadata, enableKeyTermsSuggestionsByDocumentType, enableKeyTermsSuggestionsByDocumentTypeMetadata, enableLargeFileSupport, enableLargeFileSupportMetadata, enableMultiUserRepositoryFeatures, enableMultiUserRepositoryFeaturesMetadata, enableParticipantRecipientSettingMetadata, enablePaymentProcessing, enablePaymentProcessingMetadata, enablePDFAConversion, enablePDFAConversionMetadata, enablePowerForm, enablePowerFormDirect, enablePowerFormDirectMetadata, enablePowerFormMetadata, enablePremiumDataVerificationExtensions, enablePremiumDataVerificationExtensionsMetadata, enableRecipientDomainValidation, enableRecipientDomainValidationMetadata, enableRecipientMayProvidePhoneNumber, enableRecipientMayProvidePhoneNumberMetadata, enableReportLinks, enableReportLinksMetadata, enableRequireSignOnPaper, enableRequireSignOnPaperMetadata, enableReservedDomain, enableReservedDomainMetadata, enableResponsiveSigning, enableResponsiveSigningMetadata, enableScheduledRelease, enableScheduledReleaseMetadata, enableSearchServiceAzureUri, enableSearchServiceAzureUriMetadata, enableSearchSiteSpecificApi, enableSearchSiteSpecificApiMetadata, enableSendingTagsFontSettings, enableSendingTagsFontSettingsMetadata, enableSendToAgent, enableSendToAgentMetadata, enableSendToIntermediary, enableSendToIntermediaryMetadata, enableSendToManage, enableSendToManageMetadata, enableSequentialSigningAPI, enableSequentialSigningAPIMetadata, enableSequentialSigningUI, enableSequentialSigningUIMetadata, enableSignerAttachments, enableSignerAttachmentsMetadata, enableSigningExtensionComments, enableSigningExtensionCommentsMetadata, enableSigningExtensionConversations, enableSigningExtensionConversationsMetadata, enableSigningOrderSettingsForAccount, enableSigningOrderSettingsForAccountMetadata, enableSignOnPaper, enableSignOnPaperMetadata, enableSignOnPaperOverride, enableSignOnPaperOverrideMetadata, enableSignWithNotary, enableSignWithNotaryMetadata, enableSmartContracts, enableSmartContractsMetadata, enableSMSAuthentication, enableSMSAuthenticationMetadata, enableSMSDeliveryAdditionalNotification, enableSMSDeliveryAdditionalNotificationMetadata, enableSMSDeliveryPrimary, enableSocialIdLogin, enableSocialIdLoginMetadata, enableStrikeThrough, enableStrikeThroughMetadata, enableTransactionPoint, enableTransactionPointMetadata, enableUnifiedRepository, enableUnifiedRepositoryMetadata, enableVaulting, enableVaultingMetadata, enableWebFormsRuntimeAPIs, enableWebFormsRuntimeAPIsMetadata, enableWebFormsSeparateUserPermissions, enableWebFormsSeparateUserPermissionsMetadata, enableWitnessing, enableWitnessingMetadata, enforceTemplateNameUniqueness, enforceTemplateNameUniquenessMetadata, enforceTlsEmails, enforceTlsEmailsMetadata, envelopeIntegrationAllowed, envelopeIntegrationAllowedMetadata, envelopeIntegrationEnabled, envelopeIntegrationEnabledMetadata, envelopeLimitsTotalDocumentSizeAllowedInMB, envelopeLimitsTotalDocumentSizeAllowedInMBEnabled, envelopeLimitsTotalDocumentSizeAllowedInMBEnabledMetadata, envelopeLimitsTotalDocumentSizeAllowedInMBMetadata, envelopeSearchMode, envelopeSearchModeMetadata, envelopeStampingDefaultValue, envelopeStampingDefaultValueMetadata, exitPrompt, exitPromptMetadata, expressSend, expressSendAllowTabs, expressSendAllowTabsMetadata, expressSendMetadata, externalDocumentSources, externalSignaturePadType, externalSignaturePadTypeMetadata, faxOutEnabled, faxOutEnabledMetadata, finishReminder, finishReminderMetadata, forbidAddingUserStamps, forbidAddingUserStampsMetadata, guidedFormsHtmlAllowed, guidedFormsHtmlAllowedMetadata, guidedFormsHtmlConversionPolicy, guidedFormsHtmlConversionPolicyMetadata, hasRecipientConnectClaimedDomain, hideAccountAddressInCoC, hideAccountAddressInCoCMetadata, hidePricing, hidePricingMetadata, idCheckConfigurations, idCheckExpire, idCheckExpireDays, idCheckExpireDaysMetadata, idCheckExpireMetadata, idCheckExpireMinutes, idCheckExpireMinutesMetadata, idCheckRequired, idCheckRequiredMetadata, identityVerification, identityVerificationMetadata, idfxKBAAuthenticationOverride, idfxKBAAuthenticationOverrideMetadata, idfxPhoneAuthenticationOverride, idfxPhoneAuthenticationOverrideMetadata, ignoreErrorIfAnchorTabNotFound, ignoreErrorIfAnchorTabNotFoundMetadataEnabled, inPersonIDCheckQuestion, inPersonIDCheckQuestionMetadata, inPersonSigningEnabled, inPersonSigningEnabledMetadata, inSessionEnabled, inSessionEnabledMetadata, inSessionSuppressEmails, inSessionSuppressEmailsMetadata, isConnectDocumentFieldsEnabled, isvOemEmbed, isvOemEmbedMetaData, linkedExternalPrimaryAccounts, maximumSigningGroups, maximumSigningGroupsMetadata, maximumUsersPerSigningGroup, maximumUsersPerSigningGroupMetadata, maxNumberOfCustomStamps, mergeMixedModeResults, mergeMixedModeResultsMetadata, mobileSessionTimeout, mobileSessionTimeoutMetadata, numberOfActiveCustomStamps, optInMobileSigningV02, optInMobileSigningV02Metadata, optInUniversalSignatures, optOutAutoNavTextAndTabColorUpdates, optOutAutoNavTextAndTabColorUpdatesMetadata, optOutNewPlatformSeal, optOutNewPlatformSealPlatformMetadata, pdfMaxChunkedUploadPartSize, pdfMaxChunkedUploadPartSizeMetadata, pdfMaxChunkedUploadTotalSize, pdfMaxChunkedUploadTotalSizeMetadata, pdfMaxIndividualUploadSize, pdfMaxIndividualUploadSizeMetadata, phoneAuthRecipientMayProvidePhoneNumber, phoneAuthRecipientMayProvidePhoneNumberMetadata, pkiSignDownloadedPDFDocs, pkiSignDownloadedPDFDocsMetadata, readOnlyMode, readOnlyModeMetadata, recipientsCanSignOffline, recipientsCanSignOfflineMetadata, recipientSigningAutoNavigationControl, recipientSigningAutoNavigationControlMetadata, require21CFRpt11Compliance, require21CFRpt11ComplianceMetadata, requireDeclineReason, requireDeclineReasonMetadata, requireExternalUserManagement, requireExternalUserManagementMetadata, requireSignerCertificateType, requireSignerCertificateTypeMetadata, rsaVeridAccountName, rsaVeridPassword, rsaVeridRuleset, rsaVeridUserId, sbsTransactionLevel, selfSignedRecipientEmailDocument, selfSignedRecipientEmailDocumentMetadata, selfSignedRecipientEmailDocumentUserOverride, selfSignedRecipientEmailDocumentUserOverrideMetadata, senderCanSignInEachLocation, senderCanSignInEachLocationMetadata, senderMustAuthenticateSigning, senderMustAuthenticateSigningMetadata, sendingTagsFontColor, sendingTagsFontColorMetadata, sendingTagsFontName, sendingTagsFontNameMetadata, sendingTagsFontSize, sendingTagsFontSizeMetadata, sendLockoutRecipientNotification, sendLockoutRecipientNotificationMetadata, sendToCertifiedDeliveryEnabled, sendToCertifiedDeliveryEnabledMetadata, sessionTimeout, sessionTimeoutMetadata, setRecipEmailLang, setRecipEmailLangMetadata, setRecipSignLang, setRecipSignLangMetadata, sharedTemplateFolders, sharedTemplateFoldersMetadata, showCompleteDialogInEmbeddedSession, showCompleteDialogInEmbeddedSessionMetadata, showConditionalRoutingOnSend, showConditionalRoutingOnSendMetadata, showInitialConditionalFields, showInitialConditionalFieldsMetadata, showLocalizedWatermarks, showLocalizedWatermarksMetadata, showMaskedFieldsWhenDownloadingDocumentAsSender, showMaskedFieldsWhenDownloadingDocumentAsSenderMetadata, showTutorials, showTutorialsMetadata, signatureProviders, signatureProvidersMetadata, signDateFormat, signDateFormatMetadata, signDateTimeAccountLanguageOverride, signDateTimeAccountLanguageOverrideMetadata, signDateTimeAccountTimezoneOverride, signDateTimeAccountTimezoneOverrideMetadata, signerAttachCertificateToEnvelopePDF, signerAttachCertificateToEnvelopePDFMetadata, signerAttachConcat, signerAttachConcatMetadata, signerCanCreateAccount, signerCanCreateAccountMetadata, signerCanSignOnMobile, signerCanSignOnMobileMetadata, signerInSessionUseEnvelopeCompleteEmail, signerInSessionUseEnvelopeCompleteEmailMetadata, signerLoginRequirements, signerLoginRequirementsMetadata, signerMustHaveAccount, signerMustHaveAccountMetadata, signerMustLoginToSign, signerMustLoginToSignMetadata, signerShowSecureFieldInitialValues, signerShowSecureFieldInitialValuesMetadata, signingSessionTimeout, signingSessionTimeoutMetadata, signingUiVersion, signingUiVersionMetadata, signTimeFormat, signTimeFormatMetadata, signTimeShowAmPm, signTimeShowAmPmMetadata, simplifiedSendingEnabled, simplifiedSendingEnabledMetadata, singleSignOnEnabled, singleSignOnEnabledMetadata, skipAuthCompletedEnvelopes, skipAuthCompletedEnvelopesMetadata, socialIdRecipAuth, socialIdRecipAuthMetadata, specifyDocumentVisibility, specifyDocumentVisibilityMetadata, startInAdvancedCorrect, startInAdvancedCorrectMetadata, supplementalDocumentsMustAccept, supplementalDocumentsMustAcceptMetadata, supplementalDocumentsMustRead, supplementalDocumentsMustReadMetadata, supplementalDocumentsMustView, supplementalDocumentsMustViewMetadata, suppressCertificateEnforcement, suppressCertificateEnforcementMetadata, tabAccountSettings, timezoneOffsetAPI, timezoneOffsetAPIMetadata, timezoneOffsetUI, timezoneOffsetUIMetadata, universalSignatureOptIn, useAccountLevelEmail, useAccountLevelEmailMetadata, useConsumerDisclosure, useConsumerDisclosureMetadata, useConsumerDisclosureWithinAccount, useConsumerDisclosureWithinAccountMetadata, useDerivedKeys, useDerivedKeysMetadata, useDocuSignExpressSignerCertificate, useDocuSignExpressSignerCertificateMetadata, useEnvelopeSearchMixedMode, useEnvelopeSearchMixedModeMetadata, useMultiAppGroupsData, useMultiAppGroupsDataMetadata, useNewBlobForPdf, useNewBlobForPdfMetadata, useNewEnvelopeSearch, useNewEnvelopeSearchMetadata, useNewEnvelopeSearchOnlyWhenSearchingAfterDate, useNewEnvelopeSearchOnlyWhenSearchingAfterDateMetadata, useNewEnvelopeSearchOnlyWithSearchTerm, useNewEnvelopeSearchOnlyWithSearchTermMetadata, useSAFESignerCertificates, useSAFESignerCertificatesMetadata, usesAPI, usesAPIMetadata, useSignatureProviderPlatform, useSignatureProviderPlatformMetadata, useSmartContractsV1, validationsAllowed, validationsAllowedMetadata, validationsBrand, validationsBrandMetadata, validationsCadence, validationsCadenceMetadata, validationsEnabled, validationsEnabledMetadata, validationsReport, validationsReportMetadata, waterMarkEnabled, waterMarkEnabledMetadata, writeReminderToEnvelopeHistory, writeReminderToEnvelopeHistoryMetadata, wurflMinAllowableScreenSize, wurflMinAllowableScreenSizeMetadata);
   }
 
 
@@ -23609,6 +23702,8 @@ public class AccountSettingsInformation implements Serializable {
     sb.append("    convertPdfFieldsMetadata: ").append(toIndentedString(convertPdfFieldsMetadata)).append("\n");
     sb.append("    dataPopulationScope: ").append(toIndentedString(dataPopulationScope)).append("\n");
     sb.append("    dataPopulationScopeMetadata: ").append(toIndentedString(dataPopulationScopeMetadata)).append("\n");
+    sb.append("    defaultSigningResponsiveView: ").append(toIndentedString(defaultSigningResponsiveView)).append("\n");
+    sb.append("    defaultSigningResponsiveViewMetadata: ").append(toIndentedString(defaultSigningResponsiveViewMetadata)).append("\n");
     sb.append("    defaultToAdvancedEnvelopesFilterForm: ").append(toIndentedString(defaultToAdvancedEnvelopesFilterForm)).append("\n");
     sb.append("    defaultToAdvancedEnvelopesFilterFormMetadata: ").append(toIndentedString(defaultToAdvancedEnvelopesFilterFormMetadata)).append("\n");
     sb.append("    disableAutoTemplateMatching: ").append(toIndentedString(disableAutoTemplateMatching)).append("\n");
@@ -23647,6 +23742,7 @@ public class AccountSettingsInformation implements Serializable {
     sb.append("    draftEnvelopeRetentionMetadata: ").append(toIndentedString(draftEnvelopeRetentionMetadata)).append("\n");
     sb.append("    dssEnableProvisioningPenConfigurationRadminOption: ").append(toIndentedString(dssEnableProvisioningPenConfigurationRadminOption)).append("\n");
     sb.append("    dssEnableSignatureTypeCustomTagRadminRadminOption: ").append(toIndentedString(dssEnableSignatureTypeCustomTagRadminRadminOption)).append("\n");
+    sb.append("    dssSCOREFDN196RebrandDocuSignIsNotAVerb: ").append(toIndentedString(dssSCOREFDN196RebrandDocuSignIsNotAVerb)).append("\n");
     sb.append("    dssSIGN28411EnableLeavePagePromptRadminOption: ").append(toIndentedString(dssSIGN28411EnableLeavePagePromptRadminOption)).append("\n");
     sb.append("    dssSIGN29182SlideUpBarRadminOption: ").append(toIndentedString(dssSIGN29182SlideUpBarRadminOption)).append("\n");
     sb.append("    emailTemplateVersion: ").append(toIndentedString(emailTemplateVersion)).append("\n");
@@ -23655,6 +23751,8 @@ public class AccountSettingsInformation implements Serializable {
     sb.append("    enableAccessCodeGeneratorMetadata: ").append(toIndentedString(enableAccessCodeGeneratorMetadata)).append("\n");
     sb.append("    enableAccountWideSearch: ").append(toIndentedString(enableAccountWideSearch)).append("\n");
     sb.append("    enableAccountWideSearchMetadata: ").append(toIndentedString(enableAccountWideSearchMetadata)).append("\n");
+    sb.append("    enableAdditionalAdvancedWebFormsFeatures: ").append(toIndentedString(enableAdditionalAdvancedWebFormsFeatures)).append("\n");
+    sb.append("    enableAdditionalAdvancedWebFormsFeaturesMetadata: ").append(toIndentedString(enableAdditionalAdvancedWebFormsFeaturesMetadata)).append("\n");
     sb.append("    enableAdmHealthcare: ").append(toIndentedString(enableAdmHealthcare)).append("\n");
     sb.append("    enableAdmHealthcareMetadata: ").append(toIndentedString(enableAdmHealthcareMetadata)).append("\n");
     sb.append("    enableAdvancedEnvelopesSearch: ").append(toIndentedString(enableAdvancedEnvelopesSearch)).append("\n");
@@ -23766,8 +23864,6 @@ public class AccountSettingsInformation implements Serializable {
     sb.append("    enableReservedDomainMetadata: ").append(toIndentedString(enableReservedDomainMetadata)).append("\n");
     sb.append("    enableResponsiveSigning: ").append(toIndentedString(enableResponsiveSigning)).append("\n");
     sb.append("    enableResponsiveSigningMetadata: ").append(toIndentedString(enableResponsiveSigningMetadata)).append("\n");
-    sb.append("    enableSaveAsEnvelopeCustomFieldInWebForms: ").append(toIndentedString(enableSaveAsEnvelopeCustomFieldInWebForms)).append("\n");
-    sb.append("    enableSaveAsEnvelopeCustomFieldInWebFormsMetadata: ").append(toIndentedString(enableSaveAsEnvelopeCustomFieldInWebFormsMetadata)).append("\n");
     sb.append("    enableScheduledRelease: ").append(toIndentedString(enableScheduledRelease)).append("\n");
     sb.append("    enableScheduledReleaseMetadata: ").append(toIndentedString(enableScheduledReleaseMetadata)).append("\n");
     sb.append("    enableSearchServiceAzureUri: ").append(toIndentedString(enableSearchServiceAzureUri)).append("\n");

--- a/src/main/java/com/docusign/esign/model/BulkSendingCopyDocGenFormFieldRowValue.java
+++ b/src/main/java/com/docusign/esign/model/BulkSendingCopyDocGenFormFieldRowValue.java
@@ -1,0 +1,115 @@
+package com.docusign.esign.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.docusign.esign.model.BulksendingCopyDocGenFormField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.Serializable;
+
+/**
+ * BulkSendingCopyDocGenFormFieldRowValue.
+ *
+ */
+
+public class BulkSendingCopyDocGenFormFieldRowValue implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  @JsonProperty("docGenFormFieldList")
+  private java.util.List<BulksendingCopyDocGenFormField> docGenFormFieldList = null;
+
+
+  /**
+   * docGenFormFieldList.
+   *
+   * @return BulkSendingCopyDocGenFormFieldRowValue
+   **/
+  public BulkSendingCopyDocGenFormFieldRowValue docGenFormFieldList(java.util.List<BulksendingCopyDocGenFormField> docGenFormFieldList) {
+    this.docGenFormFieldList = docGenFormFieldList;
+    return this;
+  }
+  
+  /**
+   * addDocGenFormFieldListItem.
+   *
+   * @return BulkSendingCopyDocGenFormFieldRowValue
+   **/
+  public BulkSendingCopyDocGenFormFieldRowValue addDocGenFormFieldListItem(BulksendingCopyDocGenFormField docGenFormFieldListItem) {
+    if (this.docGenFormFieldList == null) {
+      this.docGenFormFieldList = new java.util.ArrayList<>();
+    }
+    this.docGenFormFieldList.add(docGenFormFieldListItem);
+    return this;
+  }
+
+  /**
+   * .
+   * @return docGenFormFieldList
+   **/
+  @Schema(description = "")
+  public java.util.List<BulksendingCopyDocGenFormField> getDocGenFormFieldList() {
+    return docGenFormFieldList;
+  }
+
+  /**
+   * setDocGenFormFieldList.
+   **/
+  public void setDocGenFormFieldList(java.util.List<BulksendingCopyDocGenFormField> docGenFormFieldList) {
+    this.docGenFormFieldList = docGenFormFieldList;
+  }
+
+
+  /**
+   * Compares objects.
+   *
+   * @return true or false depending on comparison result.
+   */
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BulkSendingCopyDocGenFormFieldRowValue bulkSendingCopyDocGenFormFieldRowValue = (BulkSendingCopyDocGenFormFieldRowValue) o;
+    return Objects.equals(this.docGenFormFieldList, bulkSendingCopyDocGenFormFieldRowValue.docGenFormFieldList);
+  }
+
+  /**
+   * Returns the HashCode.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hash(docGenFormFieldList);
+  }
+
+
+  /**
+   * Converts the given object to string.
+   */
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class BulkSendingCopyDocGenFormFieldRowValue {\n");
+    
+    sb.append("    docGenFormFieldList: ").append(toIndentedString(docGenFormFieldList)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+}
+

--- a/src/main/java/com/docusign/esign/model/BulksendingCopyDocGenFormField.java
+++ b/src/main/java/com/docusign/esign/model/BulksendingCopyDocGenFormField.java
@@ -2,6 +2,7 @@ package com.docusign.esign.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import com.docusign.esign.model.BulkSendingCopyDocGenFormFieldRowValue;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -18,6 +19,9 @@ public class BulksendingCopyDocGenFormField implements Serializable {
 
   @JsonProperty("name")
   private String name = null;
+
+  @JsonProperty("rowValues")
+  private java.util.List<BulkSendingCopyDocGenFormFieldRowValue> rowValues = null;
 
   @JsonProperty("value")
   private String value = null;
@@ -47,6 +51,46 @@ public class BulksendingCopyDocGenFormField implements Serializable {
    **/
   public void setName(String name) {
     this.name = name;
+  }
+
+
+  /**
+   * rowValues.
+   *
+   * @return BulksendingCopyDocGenFormField
+   **/
+  public BulksendingCopyDocGenFormField rowValues(java.util.List<BulkSendingCopyDocGenFormFieldRowValue> rowValues) {
+    this.rowValues = rowValues;
+    return this;
+  }
+  
+  /**
+   * addRowValuesItem.
+   *
+   * @return BulksendingCopyDocGenFormField
+   **/
+  public BulksendingCopyDocGenFormField addRowValuesItem(BulkSendingCopyDocGenFormFieldRowValue rowValuesItem) {
+    if (this.rowValues == null) {
+      this.rowValues = new java.util.ArrayList<>();
+    }
+    this.rowValues.add(rowValuesItem);
+    return this;
+  }
+
+  /**
+   * .
+   * @return rowValues
+   **/
+  @Schema(description = "")
+  public java.util.List<BulkSendingCopyDocGenFormFieldRowValue> getRowValues() {
+    return rowValues;
+  }
+
+  /**
+   * setRowValues.
+   **/
+  public void setRowValues(java.util.List<BulkSendingCopyDocGenFormFieldRowValue> rowValues) {
+    this.rowValues = rowValues;
   }
 
 
@@ -92,6 +136,7 @@ public class BulksendingCopyDocGenFormField implements Serializable {
     }
     BulksendingCopyDocGenFormField bulksendingCopyDocGenFormField = (BulksendingCopyDocGenFormField) o;
     return Objects.equals(this.name, bulksendingCopyDocGenFormField.name) &&
+        Objects.equals(this.rowValues, bulksendingCopyDocGenFormField.rowValues) &&
         Objects.equals(this.value, bulksendingCopyDocGenFormField.value);
   }
 
@@ -100,7 +145,7 @@ public class BulksendingCopyDocGenFormField implements Serializable {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(name, value);
+    return Objects.hash(name, rowValues, value);
   }
 
 
@@ -113,6 +158,7 @@ public class BulksendingCopyDocGenFormField implements Serializable {
     sb.append("class BulksendingCopyDocGenFormField {\n");
     
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    rowValues: ").append(toIndentedString(rowValues)).append("\n");
     sb.append("    value: ").append(toIndentedString(value)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/com/docusign/esign/model/NotaryRecipient.java
+++ b/src/main/java/com/docusign/esign/model/NotaryRecipient.java
@@ -71,6 +71,9 @@ public class NotaryRecipient implements Serializable {
   @JsonProperty("bulkSendV2Recipient")
   private String bulkSendV2Recipient = null;
 
+  @JsonProperty("canNotaryCorrectEnvelope")
+  private String canNotaryCorrectEnvelope = null;
+
   @JsonProperty("canSignOffline")
   private String canSignOffline = null;
 
@@ -655,6 +658,33 @@ public class NotaryRecipient implements Serializable {
    **/
   public void setBulkSendV2Recipient(String bulkSendV2Recipient) {
     this.bulkSendV2Recipient = bulkSendV2Recipient;
+  }
+
+
+  /**
+   * canNotaryCorrectEnvelope.
+   *
+   * @return NotaryRecipient
+   **/
+  public NotaryRecipient canNotaryCorrectEnvelope(String canNotaryCorrectEnvelope) {
+    this.canNotaryCorrectEnvelope = canNotaryCorrectEnvelope;
+    return this;
+  }
+
+  /**
+   * .
+   * @return canNotaryCorrectEnvelope
+   **/
+  @Schema(description = "")
+  public String getCanNotaryCorrectEnvelope() {
+    return canNotaryCorrectEnvelope;
+  }
+
+  /**
+   * setCanNotaryCorrectEnvelope.
+   **/
+  public void setCanNotaryCorrectEnvelope(String canNotaryCorrectEnvelope) {
+    this.canNotaryCorrectEnvelope = canNotaryCorrectEnvelope;
   }
 
 
@@ -3310,6 +3340,7 @@ public class NotaryRecipient implements Serializable {
         Objects.equals(this.autoRespondedReason, notaryRecipient.autoRespondedReason) &&
         Objects.equals(this.bulkRecipientsUri, notaryRecipient.bulkRecipientsUri) &&
         Objects.equals(this.bulkSendV2Recipient, notaryRecipient.bulkSendV2Recipient) &&
+        Objects.equals(this.canNotaryCorrectEnvelope, notaryRecipient.canNotaryCorrectEnvelope) &&
         Objects.equals(this.canSignOffline, notaryRecipient.canSignOffline) &&
         Objects.equals(this.clientUserId, notaryRecipient.clientUserId) &&
         Objects.equals(this.completedCount, notaryRecipient.completedCount) &&
@@ -3409,7 +3440,7 @@ public class NotaryRecipient implements Serializable {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(accessCode, accessCodeMetadata, addAccessCodeToEmail, additionalNotifications, agentCanEditEmail, agentCanEditName, allowSystemOverrideForLockedRecipient, autoNavigation, autoRespondedReason, bulkRecipientsUri, bulkSendV2Recipient, canSignOffline, clientUserId, completedCount, consentDetailsList, creationReason, customFields, declinedDateTime, declinedReason, defaultRecipient, delegatedBy, delegatedTo, deliveredDateTime, deliveryMethod, deliveryMethodMetadata, designatorId, designatorIdGuid, documentVisibility, email, emailMetadata, emailNotification, emailRecipientPostSigningURL, embeddedRecipientStartURL, errorDetails, excludedDocuments, faxNumber, faxNumberMetadata, firstName, firstNameMetadata, fullName, fullNameMetadata, idCheckConfigurationName, idCheckConfigurationNameMetadata, idCheckInformationInput, identityVerification, inheritEmailNotificationConfiguration, isBulkRecipient, isBulkRecipientMetadata, lastName, lastNameMetadata, liveOakStartURL, lockedRecipientPhoneAuthEditable, lockedRecipientSmsEditable, name, nameMetadata, notaryId, notarySignerEmailSent, notarySigners, notarySourceType, notaryThirdPartyPartner, notaryType, note, noteMetadata, offlineAttributes, phoneAuthentication, phoneNumber, proofFile, recipientAttachments, recipientAuthenticationStatus, recipientFeatureMetadata, recipientId, recipientIdGuid, recipientSignatureProviders, recipientSuppliesTabs, recipientType, recipientTypeMetadata, requireIdLookup, requireIdLookupMetadata, requireSignerCertificate, requireSignOnPaper, requireUploadSignature, roleName, routingOrder, routingOrderMetadata, sentDateTime, signatureInfo, signedDateTime, signInEachLocation, signInEachLocationMetadata, signingGroupId, signingGroupIdMetadata, signingGroupName, signingGroupUsers, smsAuthentication, socialAuthentications, status, statusCode, suppressEmails, tabs, templateLocked, templateRequired, totalTabCount, userId);
+    return Objects.hash(accessCode, accessCodeMetadata, addAccessCodeToEmail, additionalNotifications, agentCanEditEmail, agentCanEditName, allowSystemOverrideForLockedRecipient, autoNavigation, autoRespondedReason, bulkRecipientsUri, bulkSendV2Recipient, canNotaryCorrectEnvelope, canSignOffline, clientUserId, completedCount, consentDetailsList, creationReason, customFields, declinedDateTime, declinedReason, defaultRecipient, delegatedBy, delegatedTo, deliveredDateTime, deliveryMethod, deliveryMethodMetadata, designatorId, designatorIdGuid, documentVisibility, email, emailMetadata, emailNotification, emailRecipientPostSigningURL, embeddedRecipientStartURL, errorDetails, excludedDocuments, faxNumber, faxNumberMetadata, firstName, firstNameMetadata, fullName, fullNameMetadata, idCheckConfigurationName, idCheckConfigurationNameMetadata, idCheckInformationInput, identityVerification, inheritEmailNotificationConfiguration, isBulkRecipient, isBulkRecipientMetadata, lastName, lastNameMetadata, liveOakStartURL, lockedRecipientPhoneAuthEditable, lockedRecipientSmsEditable, name, nameMetadata, notaryId, notarySignerEmailSent, notarySigners, notarySourceType, notaryThirdPartyPartner, notaryType, note, noteMetadata, offlineAttributes, phoneAuthentication, phoneNumber, proofFile, recipientAttachments, recipientAuthenticationStatus, recipientFeatureMetadata, recipientId, recipientIdGuid, recipientSignatureProviders, recipientSuppliesTabs, recipientType, recipientTypeMetadata, requireIdLookup, requireIdLookupMetadata, requireSignerCertificate, requireSignOnPaper, requireUploadSignature, roleName, routingOrder, routingOrderMetadata, sentDateTime, signatureInfo, signedDateTime, signInEachLocation, signInEachLocationMetadata, signingGroupId, signingGroupIdMetadata, signingGroupName, signingGroupUsers, smsAuthentication, socialAuthentications, status, statusCode, suppressEmails, tabs, templateLocked, templateRequired, totalTabCount, userId);
   }
 
 
@@ -3432,6 +3463,7 @@ public class NotaryRecipient implements Serializable {
     sb.append("    autoRespondedReason: ").append(toIndentedString(autoRespondedReason)).append("\n");
     sb.append("    bulkRecipientsUri: ").append(toIndentedString(bulkRecipientsUri)).append("\n");
     sb.append("    bulkSendV2Recipient: ").append(toIndentedString(bulkSendV2Recipient)).append("\n");
+    sb.append("    canNotaryCorrectEnvelope: ").append(toIndentedString(canNotaryCorrectEnvelope)).append("\n");
     sb.append("    canSignOffline: ").append(toIndentedString(canSignOffline)).append("\n");
     sb.append("    clientUserId: ").append(toIndentedString(clientUserId)).append("\n");
     sb.append("    completedCount: ").append(toIndentedString(completedCount)).append("\n");

--- a/src/main/java/com/docusign/esign/model/TabAccountSettings.java
+++ b/src/main/java/com/docusign/esign/model/TabAccountSettings.java
@@ -59,6 +59,12 @@ public class TabAccountSettings implements Serializable {
   @JsonProperty("drawTabsMetadata")
   private SettingsMetadata drawTabsMetadata = null;
 
+  @JsonProperty("enableTabAgreementDetails")
+  private String enableTabAgreementDetails = null;
+
+  @JsonProperty("enableTabAgreementDetailsMetadata")
+  private SettingsMetadata enableTabAgreementDetailsMetadata = null;
+
   @JsonProperty("firstLastEmailTabsEnabled")
   private String firstLastEmailTabsEnabled = null;
 
@@ -525,6 +531,60 @@ public class TabAccountSettings implements Serializable {
    **/
   public void setDrawTabsMetadata(SettingsMetadata drawTabsMetadata) {
     this.drawTabsMetadata = drawTabsMetadata;
+  }
+
+
+  /**
+   * enableTabAgreementDetails.
+   *
+   * @return TabAccountSettings
+   **/
+  public TabAccountSettings enableTabAgreementDetails(String enableTabAgreementDetails) {
+    this.enableTabAgreementDetails = enableTabAgreementDetails;
+    return this;
+  }
+
+  /**
+   * .
+   * @return enableTabAgreementDetails
+   **/
+  @Schema(description = "")
+  public String getEnableTabAgreementDetails() {
+    return enableTabAgreementDetails;
+  }
+
+  /**
+   * setEnableTabAgreementDetails.
+   **/
+  public void setEnableTabAgreementDetails(String enableTabAgreementDetails) {
+    this.enableTabAgreementDetails = enableTabAgreementDetails;
+  }
+
+
+  /**
+   * enableTabAgreementDetailsMetadata.
+   *
+   * @return TabAccountSettings
+   **/
+  public TabAccountSettings enableTabAgreementDetailsMetadata(SettingsMetadata enableTabAgreementDetailsMetadata) {
+    this.enableTabAgreementDetailsMetadata = enableTabAgreementDetailsMetadata;
+    return this;
+  }
+
+  /**
+   * .
+   * @return enableTabAgreementDetailsMetadata
+   **/
+  @Schema(description = "")
+  public SettingsMetadata getEnableTabAgreementDetailsMetadata() {
+    return enableTabAgreementDetailsMetadata;
+  }
+
+  /**
+   * setEnableTabAgreementDetailsMetadata.
+   **/
+  public void setEnableTabAgreementDetailsMetadata(SettingsMetadata enableTabAgreementDetailsMetadata) {
+    this.enableTabAgreementDetailsMetadata = enableTabAgreementDetailsMetadata;
   }
 
 
@@ -1366,6 +1426,8 @@ public class TabAccountSettings implements Serializable {
         Objects.equals(this.dataFieldSizeMetadata, tabAccountSettings.dataFieldSizeMetadata) &&
         Objects.equals(this.drawTabsEnabled, tabAccountSettings.drawTabsEnabled) &&
         Objects.equals(this.drawTabsMetadata, tabAccountSettings.drawTabsMetadata) &&
+        Objects.equals(this.enableTabAgreementDetails, tabAccountSettings.enableTabAgreementDetails) &&
+        Objects.equals(this.enableTabAgreementDetailsMetadata, tabAccountSettings.enableTabAgreementDetailsMetadata) &&
         Objects.equals(this.firstLastEmailTabsEnabled, tabAccountSettings.firstLastEmailTabsEnabled) &&
         Objects.equals(this.firstLastEmailTabsMetadata, tabAccountSettings.firstLastEmailTabsMetadata) &&
         Objects.equals(this.listTabsEnabled, tabAccountSettings.listTabsEnabled) &&
@@ -1403,7 +1465,7 @@ public class TabAccountSettings implements Serializable {
    */
   @Override
   public int hashCode() {
-    return Objects.hash(allowTabOrder, allowTabOrderMetadata, approveDeclineTabsEnabled, approveDeclineTabsMetadata, calculatedFieldsEnabled, calculatedFieldsMetadata, checkboxTabsEnabled, checkBoxTabsMetadata, dataFieldRegexEnabled, dataFieldRegexMetadata, dataFieldSizeEnabled, dataFieldSizeMetadata, drawTabsEnabled, drawTabsMetadata, firstLastEmailTabsEnabled, firstLastEmailTabsMetadata, listTabsEnabled, listTabsMetadata, noteTabsEnabled, noteTabsMetadata, numericalTabsEnabled, numericalTabsMetadata, prefillTabsEnabled, prefillTabsMetadata, radioTabsEnabled, radioTabsMetadata, savingCustomTabsEnabled, savingCustomTabsMetadata, senderToChangeTabAssignmentsEnabled, senderToChangeTabAssignmentsMetadata, sharedCustomTabsEnabled, sharedCustomTabsMetadata, tabDataLabelEnabled, tabDataLabelMetadata, tabLocationEnabled, tabLocationMetadata, tabLockingEnabled, tabLockingMetadata, tabScaleEnabled, tabScaleMetadata, tabTextFormattingEnabled, tabTextFormattingMetadata, textTabsEnabled, textTabsMetadata);
+    return Objects.hash(allowTabOrder, allowTabOrderMetadata, approveDeclineTabsEnabled, approveDeclineTabsMetadata, calculatedFieldsEnabled, calculatedFieldsMetadata, checkboxTabsEnabled, checkBoxTabsMetadata, dataFieldRegexEnabled, dataFieldRegexMetadata, dataFieldSizeEnabled, dataFieldSizeMetadata, drawTabsEnabled, drawTabsMetadata, enableTabAgreementDetails, enableTabAgreementDetailsMetadata, firstLastEmailTabsEnabled, firstLastEmailTabsMetadata, listTabsEnabled, listTabsMetadata, noteTabsEnabled, noteTabsMetadata, numericalTabsEnabled, numericalTabsMetadata, prefillTabsEnabled, prefillTabsMetadata, radioTabsEnabled, radioTabsMetadata, savingCustomTabsEnabled, savingCustomTabsMetadata, senderToChangeTabAssignmentsEnabled, senderToChangeTabAssignmentsMetadata, sharedCustomTabsEnabled, sharedCustomTabsMetadata, tabDataLabelEnabled, tabDataLabelMetadata, tabLocationEnabled, tabLocationMetadata, tabLockingEnabled, tabLockingMetadata, tabScaleEnabled, tabScaleMetadata, tabTextFormattingEnabled, tabTextFormattingMetadata, textTabsEnabled, textTabsMetadata);
   }
 
 
@@ -1429,6 +1491,8 @@ public class TabAccountSettings implements Serializable {
     sb.append("    dataFieldSizeMetadata: ").append(toIndentedString(dataFieldSizeMetadata)).append("\n");
     sb.append("    drawTabsEnabled: ").append(toIndentedString(drawTabsEnabled)).append("\n");
     sb.append("    drawTabsMetadata: ").append(toIndentedString(drawTabsMetadata)).append("\n");
+    sb.append("    enableTabAgreementDetails: ").append(toIndentedString(enableTabAgreementDetails)).append("\n");
+    sb.append("    enableTabAgreementDetailsMetadata: ").append(toIndentedString(enableTabAgreementDetailsMetadata)).append("\n");
     sb.append("    firstLastEmailTabsEnabled: ").append(toIndentedString(firstLastEmailTabsEnabled)).append("\n");
     sb.append("    firstLastEmailTabsMetadata: ").append(toIndentedString(firstLastEmailTabsMetadata)).append("\n");
     sb.append("    listTabsEnabled: ").append(toIndentedString(listTabsEnabled)).append("\n");


### PR DESCRIPTION
### Breaking Changes

<details>
<summary>API Changes (Click to expand)</summary>

<div style="margin-left: 20px;">

<br/>
Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.

  ## Endpoint-Specific Changes

  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
  Added new optional query parameter named `include_anchor_tab_locations` of type string.

  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
  Added new optional query parameter named `recycle_on_void` of type string.

  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.

  ## Model Changes

  ### Updated existing models

  ### `accountInformation`

  - **Added fields:**
    - `freeEnvelopeSendsRemainingForAdvancedDocGen`

  ### `accountSettingsInformation`

  - **Added fields:**
    - `defaultSigningResponsiveView`
    - `defaultSigningResponsiveViewMetadata`
    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
    - `enableAdditionalAdvancedWebFormsFeatures`
    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`

- **Removed fields:**
    - `enableSaveAsEnvelopeCustomFieldInWebForms`
    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`

### `bulksendingCopyDocGenFormField`

- **Added field:**
  - `rowValues`

### `notaryRecipient`

- **Added field:**
  - `canNotaryCorrectEnvelope`

### `tabAccountSettings`

- **Added field:**
  - `enableTabAgreementDetails`
  - `enableTabAgreementDetailsMetadata`


### Newly added Models

- `bulkSendingCopyDocGenFormFieldRowValue`

</div>
</details>

### Other Changes
- Updated the SDK release version.

