### PR TITLE
Version 6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,79 @@
 # DocuSign Java Client Changelog
 See [DocuSign Support Center](https://support.docusign.com/en/releasenotes/) for Product Release Notes.
 
+## [v6.0.0] - eSignature API v2.1-24.2.00.00 - 2024-07-25
+### Breaking Changes
+
+<details>
+<summary>API Changes (Click to expand)</summary>
+
+<div style="margin-left: 20px;">
+
+<br/>
+Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.
+
+  ## Endpoint-Specific Changes
+
+  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
+  Added new optional query parameter named `include_anchor_tab_locations` of type string.
+
+  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
+  Added new optional query parameter named `recycle_on_void` of type string.
+
+  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
+  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.
+
+  ## Model Changes
+
+  ### Updated existing models
+
+  ### `accountInformation`
+
+  - **Added fields:**
+    - `freeEnvelopeSendsRemainingForAdvancedDocGen`
+
+  ### `accountSettingsInformation`
+
+  - **Added fields:**
+    - `defaultSigningResponsiveView`
+    - `defaultSigningResponsiveViewMetadata`
+    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
+    - `enableAdditionalAdvancedWebFormsFeatures`
+    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`
+
+- **Removed fields:**
+    - `enableSaveAsEnvelopeCustomFieldInWebForms`
+    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`
+
+### `bulksendingCopyDocGenFormField`
+
+- **Added field:**
+  - `rowValues`
+
+### `notaryRecipient`
+
+- **Added field:**
+  - `canNotaryCorrectEnvelope`
+
+### `tabAccountSettings`
+
+- **Added field:**
+  - `enableTabAgreementDetails`
+  - `enableTabAgreementDetailsMetadata`
+
+
+### Newly added Models
+
+- `bulkSendingCopyDocGenFormFieldRowValue`
+
+</div>
+</details>
+- Deprecation of OLTU library: The OLTU library for handling OAuth is no longer used.
+
+### Other Changes
+- Upgradation of OWASP for vulnerability check of dependencies.
+- Updated the SDK release version.
+
 ## [v6.0.0-RC2] - eSignature API v2.1-24.2.00.00 - 2024-07-12
 ### Changed
 - Deprecation of OLTU library: The OLTU library for handling OAuth is no longer used.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This client SDK is provided as open source, which enables you to customize its f
     <dependency>
       <groupId>com.docusign</groupId>
       <artifactId>docusign-esign-java</artifactId>
-      <version>6.0.0-RC2</version>
+      <version>6.0.0</version>
     </dependency>
     ```
 8. If your project is still open, restart Eclipse.

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
     <artifactId>docusign-esign-java</artifactId>
     <packaging>jar</packaging>
     <name>docusign-esign-java</name>
-    <version>6.0.0-RC2</version>
+    <version>6.0.0</version>
     <url>https://developers.docusign.com</url>
-    <description>The official DocuSign eSignature JAVA client is based on version 2.1 of the DocuSign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
+    <description>The official Docusign eSignature JAVA client is based on version 2.1 of the Docusign REST API and provides libraries for JAVA application integration. It is recommended that you use this version of the library for new development.</description>
 
     <prerequisites>
         <maven>2.2.0</maven>

--- a/src/main/java/com/docusign/esign/client/ApiClient.java
+++ b/src/main/java/com/docusign/esign/client/ApiClient.java
@@ -95,7 +95,7 @@ public class ApiClient {
     String javaVersion = System.getProperty("java.version");
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/v2.1/6.0.0-RC2/Java/" + javaVersion);
+    setUserAgent("Swagger-Codegen/v2.1/6.0.0/Java/" + javaVersion);
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
@@ -633,7 +633,7 @@ public class ApiClient {
    *
    * @param clientId OAuth2 client ID: Identifies the client making the request.
    * Client applications may be scoped to a limited set of system access.
-   * @param clientSecret the secret key you generated when you set up the integration in DocuSign Admin console.
+   * @param clientSecret the secret key you generated when you set up the integration in Docusign Admin console.
    * @param code The authorization code that you received from the <i>getAuthorizationUri</i> callback.
    * @return OAuth.OAuthToken object.
    * @throws ApiException if the HTTP call status is different than 2xx.
@@ -782,13 +782,13 @@ public class ApiClient {
   }
 
   /**
-   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from DocuSign.
+   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from Docusign.
    * @param publicKeyFilename the filename of the RSA public key
    * @param privateKeyFilename the filename of the RSA private key
-   * @param oAuthBasePath DocuSign OAuth base path (account-d.docusign.com for the developer sandbox
+   * @param oAuthBasePath Docusign OAuth base path (account-d.docusign.com for the developer sandbox
  			and account.docusign.com for the production platform)
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
-   * @param userId DocuSign user Id to be impersonated (This is a UUID)
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
+   * @param userId Docusign user Id to be impersonated (This is a UUID)
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
    * @throws ApiException if there is an error while exchanging the JWT with an access token
    * @throws IOException if there is an issue with either the public or private file
@@ -852,9 +852,9 @@ public class ApiClient {
   }
 
   /**
-   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from DocuSign.
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
-   * @param userId DocuSign user Id to be impersonated (This is a UUID)
+   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from Docusign.
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
+   * @param userId Docusign user Id to be impersonated (This is a UUID)
    * @param scopes the list of requested scopes. Values include {@link OAuth#Scope_SIGNATURE}, {@link OAuth#Scope_EXTENDED}, {@link OAuth#Scope_IMPERSONATION}. You can also pass any advanced scope.
    * @param rsaPrivateKey the byte contents of the RSA private key
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
@@ -926,8 +926,8 @@ public class ApiClient {
 
   /**
    * <b>RESERVED FOR PARTNERS</b> Request JWT Application Token.
-   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from DocuSign
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
+   * Configures the current instance of ApiClient with a fresh OAuth JWT access token from Docusign
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
    * @param scopes the list of requested scopes. Values include {@link OAuth#Scope_SIGNATURE}, {@link OAuth#Scope_EXTENDED}, {@link OAuth#Scope_IMPERSONATION}. You can also pass any advanced scope.
    * @param rsaPrivateKey the byte contents of the RSA private key
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
@@ -1423,7 +1423,7 @@ public class ApiClient {
       }	
     }
 
-    // Add DocuSign Tracking Header
+    // Add Docusign Tracking Header
     invocationBuilder = invocationBuilder.header("X-DocuSign-SDK", "Java");
 
     if (body == null && formParams.isEmpty()) {

--- a/src/main/java/com/docusign/esign/client/auth/JWTUtils.java
+++ b/src/main/java/com/docusign/esign/client/auth/JWTUtils.java
@@ -34,10 +34,10 @@ public class JWTUtils {
    * Helper method to create a JWT token for the JWT flow.
    *
    * @param rsaPrivateKey the byte contents of the RSA private key
-   * @param oAuthBasePath DocuSign OAuth base path (account-d.docusign.com for the developer sandbox
+   * @param oAuthBasePath Docusign OAuth base path (account-d.docusign.com for the developer sandbox
    *     and account.docusign.com for the production platform)
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
-   * @param userId DocuSign user Id to be impersonated (This is a UUID)
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
+   * @param userId Docusign user Id to be impersonated (This is a UUID)
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
    * @param scopes space-separated string that represents the list of scopes to grant to the OAuth
    *     token.
@@ -88,10 +88,10 @@ public class JWTUtils {
    *
    * @param publicKeyFilename the filename of the RSA public key
    * @param privateKeyFilename the filename of the RSA private key
-   * @param oAuthBasePath DocuSign OAuth base path (account-d.docusign.com for the developer sandbox
+   * @param oAuthBasePath Docusign OAuth base path (account-d.docusign.com for the developer sandbox
    *     and account.docusign.com for the production platform)
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
-   * @param userId DocuSign user Id to be impersonated (This is a UUID)
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
+   * @param userId Docusign user Id to be impersonated (This is a UUID)
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
    * @return a fresh JWT token
    * @throws JWTCreationException if not able to create a JWT token from the input parameters
@@ -113,10 +113,10 @@ public class JWTUtils {
    *
    * @param publicKeyFilename the filename of the RSA public key
    * @param privateKeyFilename the filename of the RSA private key
-   * @param oAuthBasePath DocuSign OAuth base path (account-d.docusign.com for the developer sandbox
+   * @param oAuthBasePath Docusign OAuth base path (account-d.docusign.com for the developer sandbox
    *     and account.docusign.com for the production platform)
-   * @param clientId DocuSign OAuth Client Id (AKA Integrator Key)
-   * @param userId DocuSign user Id to be impersonated (This is a UUID)
+   * @param clientId Docusign OAuth Client Id (AKA Integrator Key)
+   * @param userId Docusign user Id to be impersonated (This is a UUID)
    * @param expiresIn number of seconds remaining before the JWT assertion is considered as invalid
    * @param scopes space-separated string that represents the list of scopes to grant to the OAuth
    *    token.

--- a/src/main/java/com/docusign/esign/client/auth/OAuth.java
+++ b/src/main/java/com/docusign/esign/client/auth/OAuth.java
@@ -493,7 +493,7 @@ public class OAuth implements Authentication {
     /**
      *
      * OAuthToken model with the following properties.
-     * <br><b>accessToken</b>: the token you will use in the Authorization header of calls to the DocuSign API.
+     * <br><b>accessToken</b>: the token you will use in the Authorization header of calls to the Docusign API.
      * <br><b>tokenType</b>: this is the type of the accessToken. It is usually "Bearer".
      * <br><b>refreshToken</b>: a token you can use to get a new accessToken without requiring user interaction.
      * <br><b>expiresIn</b>: the number of seconds before the accessToken expires.
@@ -746,8 +746,8 @@ public class OAuth implements Authentication {
     /**
      *
      * Organization model with the below properties.
-     * <br><b>organizationId</b>: the organization ID GUID if DocuSign Org Admin is enabled.
-     * <br><b>links</b>: this is list of organization direct links associated with the DocuSign account.
+     * <br><b>organizationId</b>: the organization ID GUID if Docusign Org Admin is enabled.
+     * <br><b>links</b>: this is list of organization direct links associated with the Docusign account.
      *
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -848,8 +848,8 @@ public class OAuth implements Authentication {
      * <br><b>isDefault</b>: whether this is the default account, when the user has access to multiple accounts.
      * <br><b>accountName</b>: the human-readable name of the account.
      * <br><b>baseUri</b>: the base URI associated with this account.
-     * It also tells which DocuSign data center the account is hosted on.
-     * <br><b>organization</b>: If DocuSign Org Admin is enabled on this account,
+     * It also tells which Docusign data center the account is hosted on.
+     * <br><b>organization</b>: If Docusign Org Admin is enabled on this account,
      * this property contains the organization information.
      *
      */
@@ -1015,7 +1015,7 @@ public class OAuth implements Authentication {
      *
      * UserInfo model with the below properties.
      * <br><b>sub</b>: the user ID GUID.
-     * <br><b>accounts</b>: this is list of DocuSign accounts associated with the current user.
+     * <br><b>accounts</b>: this is list of Docusign accounts associated with the current user.
      * <br><b>name</b>: the user's full name.
      * <br><b>givenName</b>: the user's given name.
      * <br><b>familyName</b>: the user's family name.


### PR DESCRIPTION
### Breaking Changes

<details>
<summary>API Changes (Click to expand)</summary>

<div style="margin-left: 20px;">

<br/>
Added support for version v2.1-24.2.00.00 of the Docusign ESignature API.

  ## Endpoint-Specific Changes

  ### Updated [Envelopes: get](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)
  Added new optional query parameter named `include_anchor_tab_locations` of type string.

  ### Updated [Envelopes: update](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)
  Added new optional query parameter named `recycle_on_void` of type string.

  ### Updated [EnvelopeViews : createCorrect](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/)
  Request body object `correctViewRequest` has been changed to `envelopeViewRequest`.

  ## Model Changes

  ### Updated existing models

  ### `accountInformation`

  - **Added fields:**
    - `freeEnvelopeSendsRemainingForAdvancedDocGen`

  ### `accountSettingsInformation`

  - **Added fields:**
    - `defaultSigningResponsiveView`
    - `defaultSigningResponsiveViewMetadata`
    - `dss_SCOREFDN_196_Rebrand_DocuSignIsNotAVerb`
    - `enableAdditionalAdvancedWebFormsFeatures`
    - `enableAdditionalAdvancedWebFormsFeaturesMetadata`

- **Removed fields:**
    - `enableSaveAsEnvelopeCustomFieldInWebForms`
    - `enableSaveAsEnvelopeCustomFieldInWebFormsMetadata`

### `bulksendingCopyDocGenFormField`

- **Added field:**
  - `rowValues`

### `notaryRecipient`

- **Added field:**
  - `canNotaryCorrectEnvelope`

### `tabAccountSettings`

- **Added field:**
  - `enableTabAgreementDetails`
  - `enableTabAgreementDetailsMetadata`


### Newly added Models

- `bulkSendingCopyDocGenFormFieldRowValue`

</div>
</details>
- Deprecation of OLTU library: The OLTU library for handling OAuth is no longer used.

### Other Changes
- Upgradation of OWASP for vulnerability check of dependencies.
- Updated the SDK release version.
